### PR TITLE
Fix/#22/pagination scroll issue(swm 182)

### DIFF
--- a/src/api/lectures/search.ts
+++ b/src/api/lectures/search.ts
@@ -59,7 +59,7 @@ export async function fetchLectureDetailIndex(
 
 export async function fetchLectureDetailReview(
   lecture_code: string,
-  params?: LectureIndexParams
+  params?: LectureReviewParams
 ) {
   const headers = await getAuthorizedHeaders();
   return await fetch(

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,8 +1,9 @@
+'use client';
 import SearchResultsHeading from '@/src/components/search/SearchResultsHeading';
 import SearchResultsList from '@/src/components/search/SearchResultsList';
 import SearchResultsSkeleton from '@/src/components/search/SearchResultsSkeleton';
 import { LIMIT_PER_FETCH } from '@/src/constants/search/search';
-import { Suspense } from 'react';
+import { Suspense, useRef } from 'react';
 
 type Props = {
   searchParams: SearchLectureParams;
@@ -10,21 +11,31 @@ type Props = {
 
 export default async function SearchResults({ searchParams }: Props) {
   const requestParam: SearchLectureParams = {
-    keyword: searchParams.keyword === undefined ? '' : decodeURIComponent(searchParams.keyword),
+    keyword:
+      searchParams.keyword === undefined
+        ? ''
+        : decodeURIComponent(searchParams.keyword),
     limit: searchParams.limit ? Number(searchParams.limit) : LIMIT_PER_FETCH,
     next_page_token: '',
     filter: searchParams.filter ? searchParams.filter : 'all'
   };
 
+  const searchResultPageRef = useRef<number>(0);
+
   return (
     <>
       <SearchResultsHeading keyword={requestParam.keyword} />
-      <Suspense fallback={<SearchResultsSkeleton limit={requestParam.limit} />}>
+      <Suspense
+        fallback={
+          <SearchResultsSkeleton
+            searchResultPageRef={searchResultPageRef}
+            limit={requestParam.limit}
+          />
+        }
+      >
         <SearchResultsList
-          keyword={requestParam.keyword}
-          limit={requestParam.limit}
-          next_page_token=''
-          filter={requestParam.filter}
+          requestParam={requestParam}
+          searchResultPageRef={searchResultPageRef}
         />
       </Suspense>
     </>

--- a/src/components/lectureDetail/LectureDetailModal.tsx
+++ b/src/components/lectureDetail/LectureDetailModal.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation';
 import Modal from '../ui/Modal';
 import LectureDetailTabNav from './LectureDetailTabNav';
-import { Suspense } from 'react';
+import { Suspense, useRef } from 'react';
 import LectureDetailIndexList from './index/LectureDetailIndexList';
 import LectureDetailReviewList from './review/LectureDetailReviewList';
 import LectureDetailCard from './LectureDetailCard';
@@ -27,6 +27,8 @@ export default function LectureDetailModal({
   const router = useRouter();
   const onCloseHandler =
     navigationType === 'soft' ? router.back : () => router.replace('/');
+  const indexPageRef = useRef<number>(0);
+  const reviewPageRef = useRef<number>(0);
 
   return (
     <Modal
@@ -42,10 +44,16 @@ export default function LectureDetailModal({
             <LectureDetailHeading title={'목차'} />
             <Suspense
               fallback={
-                <LectureDetailIndexSkeleton limit={INDEX_SKELETON_LIMIT} />
+                <LectureDetailIndexSkeleton
+                  indexPageRef={indexPageRef}
+                  limit={INDEX_SKELETON_LIMIT}
+                />
               }
             >
-              <LectureDetailIndexList lectureCode={lecture_code} />
+              <LectureDetailIndexList
+                indexPageRef={indexPageRef}
+                lectureCode={lecture_code}
+              />
             </Suspense>
           </>
         )}
@@ -53,9 +61,17 @@ export default function LectureDetailModal({
       <section id='reviews'>
         <LectureDetailHeading title={'후기'} />
         <Suspense
-          fallback={<LectureDetailReviewSkeleton limit={REVIEW_LIMIT} />}
+          fallback={
+            <LectureDetailReviewSkeleton
+              reviewPageRef={reviewPageRef}
+              limit={REVIEW_LIMIT}
+            />
+          }
         >
-          <LectureDetailReviewList lectureCode={lecture_code} />
+          <LectureDetailReviewList
+            reviewPageRef={reviewPageRef}
+            lectureCode={lecture_code}
+          />
         </Suspense>
       </section>
     </Modal>

--- a/src/components/lectureDetail/index/LectureDetailIndexList.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexList.tsx
@@ -19,6 +19,13 @@ export default async function LectureDetailIndexList({
   lectureCode: string;
   indexPageRef: React.MutableRefObject<number>;
 }) {
+  const updateIndexPageRef = (next_page_token: string) => {
+    if (next_page_token === '') {
+      indexPageRef.current = 0;
+    }
+    indexPageRef.current += 1;
+  };
+
   const fetchLectureIndexList = async ({
     pageParam: index_next_token = ''
   }) => {
@@ -28,8 +35,8 @@ export default async function LectureDetailIndexList({
       index_next_token
     };
 
-    indexPageRef.current += 1;
-    
+    updateIndexPageRef(index_next_token);
+
     return await fetchLectureDetailIndex(lectureCode, params)
       .then((res) => {
         return res;

--- a/src/components/lectureDetail/index/LectureDetailIndexList.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexList.tsx
@@ -12,11 +12,13 @@ import {
 import LoadMoreButton from '../../ui/LoadMoreButton';
 import setErrorToast from '@/src/util/setErrorToast';
 
-type Props = {
+export default async function LectureDetailIndexList({
+  lectureCode,
+  indexPageRef
+}: {
   lectureCode: string;
-};
-
-export default async function LectureDetailIndexList({ lectureCode }: Props) {
+  indexPageRef: React.MutableRefObject<number>;
+}) {
   const fetchLectureIndexList = async ({
     pageParam: index_next_token = ''
   }) => {
@@ -25,6 +27,9 @@ export default async function LectureDetailIndexList({ lectureCode }: Props) {
       index_limit: INDEX_LIMIT,
       index_next_token
     };
+
+    indexPageRef.current += 1;
+    
     return await fetchLectureDetailIndex(lectureCode, params)
       .then((res) => {
         return res;

--- a/src/components/lectureDetail/index/LectureDetailIndexSkeleton.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexSkeleton.tsx
@@ -1,13 +1,15 @@
-import { memo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 
 type Props = {
   limit: number;
+  indexPageRef: React.MutableRefObject<number>;
 };
 
-const LectureDetailIndexSkeleton = ({ limit }: Props) => {
-  const skeletonArray = [...new Array(limit)].map((_, i) => i + 1);
+const LectureDetailIndexSkeleton = ({ limit, indexPageRef }: Props) => {
+  const skeletonArray = [...new Array(limit * indexPageRef.current)].map(
+    (_, i) => i + 1
+  );
 
   const StyledSkeleton = () => {
     return (
@@ -27,4 +29,4 @@ const LectureDetailIndexSkeleton = ({ limit }: Props) => {
   );
 };
 
-export default memo(LectureDetailIndexSkeleton);
+export default LectureDetailIndexSkeleton;

--- a/src/components/lectureDetail/review/LectureDetailReviewList.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewList.tsx
@@ -11,8 +11,7 @@ import {
 } from '@/src/constants/detail/detail';
 import LectureDetailReviewCard from './LectureDetailReviewCard';
 import setErrorToast from '@/src/util/setErrorToast';
-
-let offset = 0;
+import { useRef } from 'react';
 
 export default async function LectureDetailReviewList({
   lectureCode,
@@ -21,18 +20,30 @@ export default async function LectureDetailReviewList({
   lectureCode: string;
   reviewPageRef: React.MutableRefObject<number>;
 }) {
-  const fetchLectureReviewList = async () => {
-    const params: LectureDeatilParams = {
+  const updateReviewPageRef = (offset: number) => {
+    if (offset === 0) {
+      reviewPageRef.current = 0;
+    }
+    reviewPageRef.current += 1;
+  };
+
+  const checkNextPage = (
+    lastPage: LectureReviewList | null,
+    allPages: (LectureReviewList | null)[]
+  ) =>
+    lastPage && lastPage.length > 0 ? allPages.length * lastPage.length : 0;
+
+  const fetchLectureReviewList = async ({ pageParam: offset = 0 }) => {
+    const params: LectureReviewParams = {
       review_only: true,
       review_offset: offset,
       review_limit: REVIEW_LIMIT
     };
-    
-    reviewPageRef.current += 1;
+
+    updateReviewPageRef(offset);
 
     return await fetchLectureDetailReview(lectureCode, params)
       .then((res) => {
-        offset += res.length ? res.length : 0;
         return res;
       })
       .catch(() => {
@@ -49,8 +60,7 @@ export default async function LectureDetailReviewList({
       suspense: true,
       staleTime: STALE_TIME,
       cacheTime: CACHE_TIME,
-      getNextPageParam: (lastPage) =>
-        lastPage && lastPage.length > 0 ? true : false
+      getNextPageParam: checkNextPage
     }
   );
 

--- a/src/components/lectureDetail/review/LectureDetailReviewList.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewList.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/src/constants/detail/detail';
 import LectureDetailReviewCard from './LectureDetailReviewCard';
 import setErrorToast from '@/src/util/setErrorToast';
-import { useRef } from 'react';
 
 export default async function LectureDetailReviewList({
   lectureCode,

--- a/src/components/lectureDetail/review/LectureDetailReviewList.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewList.tsx
@@ -12,20 +12,24 @@ import {
 import LectureDetailReviewCard from './LectureDetailReviewCard';
 import setErrorToast from '@/src/util/setErrorToast';
 
-type Props = {
-  lectureCode: string;
-};
-
 let offset = 0;
 
-export default async function LectureDetailReviewList({ lectureCode }: Props) {
+export default async function LectureDetailReviewList({
+  lectureCode,
+  reviewPageRef
+}: {
+  lectureCode: string;
+  reviewPageRef: React.MutableRefObject<number>;
+}) {
   const fetchLectureReviewList = async () => {
     const params: LectureDeatilParams = {
       review_only: true,
       review_offset: offset,
       review_limit: REVIEW_LIMIT
     };
-    console.log(offset);
+    
+    reviewPageRef.current += 1;
+
     return await fetchLectureDetailReview(lectureCode, params)
       .then((res) => {
         offset += res.length ? res.length : 0;

--- a/src/components/lectureDetail/review/LectureDetailReviewSkeleton.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewSkeleton.tsx
@@ -1,13 +1,15 @@
-import { memo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 
 type Props = {
   limit: number;
+  reviewPageRef: React.MutableRefObject<number>;
 };
 
-const LectureDetailReviewSkeleton = ({ limit }: Props) => {
-  const skeletonArray = [...new Array(limit)].map((_, i) => i + 1);
+const LectureDetailReviewSkeleton = ({ limit, reviewPageRef }: Props) => {
+  const skeletonArray = [...new Array(limit * reviewPageRef.current)].map(
+    (_, i) => i + 1
+  );
 
   const StyledSkeleton = () => {
     return (
@@ -27,4 +29,4 @@ const LectureDetailReviewSkeleton = ({ limit }: Props) => {
   );
 };
 
-export default memo(LectureDetailReviewSkeleton);
+export default LectureDetailReviewSkeleton;

--- a/src/components/search/SearchResultsList.tsx
+++ b/src/components/search/SearchResultsList.tsx
@@ -21,14 +21,21 @@ export default async function SearchResultsList({
     requestParam.filter
   );
 
+  const updateSearchResultPageRef = (next_page_token: string) => {
+    if (next_page_token === '') {
+      searchResultPageRef.current = 0;
+    }
+    searchResultPageRef.current += 1;
+  };
+
   const fetchSearchResults = async ({ pageParam: next_page_token = '' }) => {
     const params: SearchLectureParams = {
       ...requestParam,
       next_page_token,
       filter
     };
-
-    searchResultPageRef.current += 1;
+    
+    updateSearchResultPageRef(next_page_token);
 
     return await fetchLecturesByKeyword(params)
       .then((res) => {

--- a/src/components/search/SearchResultsSkeleton.tsx
+++ b/src/components/search/SearchResultsSkeleton.tsx
@@ -35,7 +35,7 @@ const SearchResultsSkeleton = ({ limit, searchResultPageRef }: Props) => {
     );
   };
   return (
-    <ul className='grid grid-cols-2 gap-8 px-5 gap-y-4'>
+    <ul className='grid grid-cols-2 gap-8 px-5 mt-[5.25rem] gap-y-4'>
       {skeletonArray.map((idx) => (
         <StyledSkeleton key={'skeleton' + idx} />
       ))}

--- a/src/components/search/SearchResultsSkeleton.tsx
+++ b/src/components/search/SearchResultsSkeleton.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
   THUMBNAIL_PREVIEW_HEIGHT,
   THUMBNAIL_PREVIEW_MIN_WIDTH

--- a/src/components/search/SearchResultsSkeleton.tsx
+++ b/src/components/search/SearchResultsSkeleton.tsx
@@ -1,14 +1,19 @@
-import { THUMBNAIL_PREVIEW_HEIGHT, THUMBNAIL_PREVIEW_MIN_WIDTH } from '@/src/constants/ui/thumbnail';
-import { memo } from 'react';
+import {
+  THUMBNAIL_PREVIEW_HEIGHT,
+  THUMBNAIL_PREVIEW_MIN_WIDTH
+} from '@/src/constants/ui/thumbnail';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 
 type Props = {
   limit: number;
+  searchResultPageRef: React.MutableRefObject<number>;
 };
 
-const SearchResultsSkeleton = ({ limit }: Props)=> {
-  const skeletonArray = [...new Array(limit)].map((_, i) => i + 1);
+const SearchResultsSkeleton = ({ limit, searchResultPageRef }: Props) => {
+  const skeletonArray = [...new Array(limit * searchResultPageRef.current)].map(
+    (_, i) => i + 1
+  );
 
   const StyledSkeleton = () => {
     return (
@@ -35,5 +40,5 @@ const SearchResultsSkeleton = ({ limit }: Props)=> {
       ))}
     </ul>
   );
-}
-export default memo(SearchResultsSkeleton);
+};
+export default SearchResultsSkeleton;


### PR DESCRIPTION
## Motivation 🤔
- 페이지네이션을 적용하여 fetch하는 부분 _(강의 키워드 검색, 강의 목차, 강의 리뷰 불러오기)_ 에서 ‘더보기’ 버튼을 클릭하면 스크롤이 특정 위치로 초기화 되는 현상 발생

<br>

## Key changes ✅
- `ref`를 활용하여, 해당 컴포넌트 _(강의 검색, 목차, 리뷰)_ 에서 보여줄 카드의 개수를 저장
- 각각의 Skeleton 컴포넌트에서 해당 `ref`를 참조하여 보여줄 Skeleton의 개수 결정

![ezgif com-optimize (1)](https://github.com/4m9d/sroom-fe/assets/63336701/adab57c2-b946-453d-8b9d-619e8d39f827)

<br>

## To reviewers 🙏
- 로컬 백엔드 서버 실행 후, `npm run dev:local`로 실행해 주세요! 
- 우아한 해결방법은 아니지만... 나중에 더 좋은 해결책이 생기면 반영하겠습니다!