### PR TITLE
Feat/#24/#27/dashboard latest learning lecture(swm 207)

### DIFF
--- a/src/app/@modal/(.)search/[lecture_code]/page.tsx
+++ b/src/app/@modal/(.)search/[lecture_code]/page.tsx
@@ -4,9 +4,7 @@ import LectureDetailModal from '@/src/components/lectureDetail/LectureDetailModa
 export default async function LectureDetailModalIntercepter({
   params: { lecture_code }
 }: LectureDetailModalParams) {
-  const lectureDetail = await fetchLectureDetail(lecture_code).then(
-    (res) => res
-  );
+  const lectureDetail = await fetchLectureDetail(lecture_code);
 
   return (
     <LectureDetailModal lectureDetail={lectureDetail} navigationType='soft' />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,7 +12,7 @@ export default async function Dashboard() {
     <div>
       <DashboardHeader isEnrolled={isEnrolled} />
       <MainDashboard dashboardInfo={dashboardInfo} />
-      <LatestLearningLectures latestLearningLectures={latestLearningLectures}/>
+      {isEnrolled && <LatestLearningLectures latestLearningLectures={latestLearningLectures}/>}
     </div>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,15 +1,18 @@
 import { fetchDashboardInfo } from '@/src/api/dashboards/dashboards';
 import DashboardHeader from '@/src/components/dashboard/header/DashboardHeader';
+import LatestLearningLectures from '@/src/components/dashboard/latestLearning/LatestLearningLectures';
 import MainDashboard from '@/src/components/dashboard/main/MainDashboard';
 
 export default async function Dashboard() {
   const dashboardInfo = await fetchDashboardInfo();
-  const isEnrolled = dashboardInfo.latest.length > 0;
+  const latestLearningLectures = dashboardInfo.latest;
+  const isEnrolled = latestLearningLectures.length > 0;
 
   return (
     <div>
       <DashboardHeader isEnrolled={isEnrolled} />
       <MainDashboard dashboardInfo={dashboardInfo} />
+      <LatestLearningLectures latestLearningLectures={latestLearningLectures}/>
     </div>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import DashboardHeader from '@/src/components/dashboard/header/DashboardHeader';
 import MainDashboard from '@/src/components/dashboard/main/MainDashboard';
 
 export default async function Dashboard() {
-  const dashboardInfo = await fetchDashboardInfo().then((res) => res);
+  const dashboardInfo = await fetchDashboardInfo();
   const isEnrolled = dashboardInfo.latest.length > 0;
 
   return (

--- a/src/app/search/[lecture_code]/page.tsx
+++ b/src/app/search/[lecture_code]/page.tsx
@@ -9,9 +9,7 @@ const DynamicLectureDetailModal = dynamic(
 export default async function LectureDetail({
   params: { lecture_code }
 }: LectureDetailModalParams) {
-  const lectureDetail = await fetchLectureDetail(lecture_code).then(
-    (res) => res
-  );
+  const lectureDetail = await fetchLectureDetail(lecture_code);
 
   return (
     <DynamicLectureDetailModal

--- a/src/components/dashboard/header/DashboardHeader.tsx
+++ b/src/components/dashboard/header/DashboardHeader.tsx
@@ -7,7 +7,7 @@ type Props = {
 export default function DashboardHeader({ isEnrolled }: Props) {
   if (isEnrolled) {
     return (
-      <section className='h-64 px-20 py-10'>
+      <section className='h-64 px-20 py-10 mx-auto max-w-screen-2xl'>
         <h2 className='font-bold md:mb-2 lg:mb-3 lg:text-4xl md:text-3xl'>
           안녕하세요!
         </h2>
@@ -18,18 +18,20 @@ export default function DashboardHeader({ isEnrolled }: Props) {
     );
   } else {
     return (
-      <section className='relative flex flex-col items-center h-[23rem] px-20 pt-14 bg-zinc-100'>
-        <h2 className='mb-5 text-4xl font-bold'>반가워요!</h2>
-        <h3 className='flex flex-col items-center text-base font-semibold'>
-          <p>유튜브에 저장만 해놨던 강의, 듣다가 중간에 포기해버린 강의</p>
-          <p>이젠 스룸과 함께 체계적으로 학습을 시작해 보세요!</p>
-        </h3>
-        <div className='absolute bottom-0 flex items-end justify-between w-full px-20 gap-7'>
-          <GuideBox title='스마트한' description='유튜브 강의 검색･추천' />
-          <GuideBox title='체계적인' description='학습 일정 관리' />
-          <GuideBox title='쪽집게 AI가 생성한' description='퀴즈･요약본' />
-        </div>
-      </section>
+      <div className='bg-zinc-100'>
+        <section className='mx-auto max-w-screen-2xl relative flex flex-col items-center h-[23rem] px-20 pt-14'>
+          <h2 className='mb-5 text-4xl font-bold'>반가워요!</h2>
+          <h3 className='flex flex-col items-center text-base font-semibold'>
+            <p>유튜브에 저장만 해놨던 강의, 듣다가 중간에 포기해버린 강의</p>
+            <p>이젠 스룸과 함께 체계적으로 학습을 시작해 보세요!</p>
+          </h3>
+          <div className='absolute bottom-0 flex items-end justify-between w-full px-20 gap-7'>
+            <GuideBox title='스마트한' description='유튜브 강의 검색･추천' />
+            <GuideBox title='체계적인' description='학습 일정 관리' />
+            <GuideBox title='쪽집게 AI가 생성한' description='퀴즈･요약본' />
+          </div>
+        </section>
+      </div>
     );
   }
 }

--- a/src/components/dashboard/latestLearning/LatestLearningLectureCard.tsx
+++ b/src/components/dashboard/latestLearning/LatestLearningLectureCard.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import ProgressBar from '../../ui/ProgressBar';
+import HorizontalSmallLectureCard from '../../ui/lectureCard/HorizontalSmallLectureCard';
+import getRelativeTime from '@/src/util/day/getRelativeTime';
+import Button from '../../ui/Button';
+
+type Props = {
+  lecture: LatestLearningLecture;
+}
+
+export default function LatestLearningLectureCard({lecture}: Props) {
+  return (
+    <HorizontalSmallLectureCard
+      src={lecture.thumbnail}
+      alt={lecture.course_title}
+    >
+      <div className='flex flex-col justify-between h-full'>
+        <div className='mt-2'>
+          <p className='text-lg font-bold line-clamp-2'>
+            {lecture.course_title}
+          </p>
+          <p className='text-sm font-semibold text-zinc-500 line-clamp-1'>
+            {lecture.channel}
+          </p>
+        </div>
+        <div className='flex justify-between h-12 gap-5 mb-1'>
+          <div className='flex flex-col justify-between flex-1 py-1'>
+            <p className='text-xs text-zinc-500'>
+              총 강의 시간 : {lecture.course_duration}분 |{' '}
+              {getRelativeTime(lecture.last_view_time)}
+            </p>
+            <ProgressBar
+              className='w-full h-[5px] bg-zinc-100'
+              value={lecture.progress}
+            />
+          </div>
+          <Button className='flex justify-between w-32 text-zinc-200 bg-zinc-800'>
+            <p>바로 학습</p>
+            <p> 〉 </p>
+          </Button>
+        </div>
+      </div>
+    </HorizontalSmallLectureCard>
+  );
+}

--- a/src/components/dashboard/latestLearning/LatestLearningLectureCard.tsx
+++ b/src/components/dashboard/latestLearning/LatestLearningLectureCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 import ProgressBar from '../../ui/ProgressBar';
 import HorizontalSmallLectureCard from '../../ui/lectureCard/HorizontalSmallLectureCard';
 import getRelativeTime from '@/src/util/day/getRelativeTime';
@@ -6,9 +6,9 @@ import Button from '../../ui/Button';
 
 type Props = {
   lecture: LatestLearningLecture;
-}
+};
 
-export default function LatestLearningLectureCard({lecture}: Props) {
+export default function LatestLearningLectureCard({ lecture }: Props) {
   return (
     <HorizontalSmallLectureCard
       src={lecture.thumbnail}
@@ -24,15 +24,20 @@ export default function LatestLearningLectureCard({lecture}: Props) {
           </p>
         </div>
         <div className='flex justify-between h-10 gap-5 mb-1'>
-          <div className='flex flex-col justify-between flex-1 py-1'>
+          <div className='flex flex-col justify-between flex-1 gap-1 py-1'>
             <p className='text-xs text-zinc-500'>
-              총 강의 시간 : {lecture.course_duration}분 |{' '}
-              {getRelativeTime(lecture.last_view_time)}
+              총 강의 시간 : {lecture.duration}분 | 수강한 영상 :{' '}
+              {lecture.completed_video_count}개 / {lecture.total_video_count}개
             </p>
-            <ProgressBar
-              className='w-full h-[5px] bg-zinc-100'
-              value={lecture.progress}
-            />
+            <div className='flex items-center'>
+              <ProgressBar
+                className='w-full h-[5px] bg-zinc-100'
+                value={lecture.progress}
+              />
+              <p className='ml-2 text-xs font-semibold text-orange-500'>
+                {lecture.progress}%
+              </p>
+            </div>
           </div>
           <Button className='flex justify-between w-32 text-sm text-zinc-200 bg-zinc-800'>
             <p>바로 학습</p>

--- a/src/components/dashboard/latestLearning/LatestLearningLectureCard.tsx
+++ b/src/components/dashboard/latestLearning/LatestLearningLectureCard.tsx
@@ -23,7 +23,7 @@ export default function LatestLearningLectureCard({lecture}: Props) {
             {lecture.channel}
           </p>
         </div>
-        <div className='flex justify-between h-12 gap-5 mb-1'>
+        <div className='flex justify-between h-10 gap-5 mb-1'>
           <div className='flex flex-col justify-between flex-1 py-1'>
             <p className='text-xs text-zinc-500'>
               총 강의 시간 : {lecture.course_duration}분 |{' '}
@@ -34,7 +34,7 @@ export default function LatestLearningLectureCard({lecture}: Props) {
               value={lecture.progress}
             />
           </div>
-          <Button className='flex justify-between w-32 text-zinc-200 bg-zinc-800'>
+          <Button className='flex justify-between w-32 text-sm text-zinc-200 bg-zinc-800'>
             <p>바로 학습</p>
             <p> 〉 </p>
           </Button>

--- a/src/components/dashboard/latestLearning/LatestLearningLectures.tsx
+++ b/src/components/dashboard/latestLearning/LatestLearningLectures.tsx
@@ -1,0 +1,25 @@
+import SectionHeading from '../../ui/SectionHeading';
+import LatestLearningLectureCard from './LatestLearningLectureCard';
+
+type Props = {
+  latestLearningLectures: LatestLearningLecture[];
+};
+
+export default function LatestLearningLectures({
+  latestLearningLectures
+}: Props) {
+  return (
+    <div className='bg-zinc-100'>
+      <section className='px-20 py-20 mx-auto my-20 max-w-screen-2xl'>
+        <SectionHeading title='시작해 볼까요?' />
+        <ul className='flex flex-wrap gap-8 shrink-0'>
+          {latestLearningLectures.map((lecture) => (
+            <li key={lecture.course_id}>
+              <LatestLearningLectureCard lecture={lecture} />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/components/dashboard/main/TotalLearningTime.tsx
+++ b/src/components/dashboard/main/TotalLearningTime.tsx
@@ -1,13 +1,34 @@
+import { useCallback, useMemo } from 'react';
+
 type Props = {
   time: number;
-}
+};
 
-export default function TotalLearningTime({time}: Props) {
+export default function TotalLearningTime({ time }: Props) {
+  const timeUnitHandler = useCallback((time: number) => {
+    const timeInString = time.toString();
+    let result = [];
+
+    if (timeInString.length > 3) {
+      result = [Math.floor(time / 60).toString(), '시간'];
+    } else {
+      result = [timeInString, '분'];
+    }
+
+    return result;
+  }, []);
+
+  const [timeInString, timeUnit] = useMemo(
+    () => timeUnitHandler(time),
+    [time, timeUnitHandler]
+  );
+
   return (
     <div className='flex flex-col justify-between col-start-1 col-end-2 row-start-2 row-end-4 px-5 py-5 bg-zinc-100'>
       <p className='text-sm'>누적 수강 시간</p>
-      <p className='text-xl'>
-        <span className='font-bold text-7xl'>{time}</span>시간
+      <p className='font-bold text-7xl'>
+        {timeInString}
+        <span className='text-lg font-semibold'>{timeUnit}</span>
       </p>
     </div>
   );

--- a/src/components/dashboard/main/WeeklyCalendar.tsx
+++ b/src/components/dashboard/main/WeeklyCalendar.tsx
@@ -5,7 +5,7 @@ import {
   getPreviousWeekRange,
   getFullWeekDate
 } from '@/src/util/day/getWeekRange';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 type Props = {
   learning_history: LearningHistory[];
@@ -30,7 +30,8 @@ export default function WeeklyCalendar({ learning_history }: Props) {
   );
   const [selectedDay, setSelectedDay] = useState<weekdayKey>(7);
 
-  const findLearningHistory = (startOfWeek: string) => {
+  const findLearningHistory = useCallback((startOfWeek: string) => {
+    console.log('함수 실행!', startOfWeek);
     const weekInfo = getFullWeekDate(startOfWeek);
 
     const mappedWeekInfo: WeekInfo[] = weekInfo.map((day) => {
@@ -41,29 +42,29 @@ export default function WeeklyCalendar({ learning_history }: Props) {
       return { ...day, learningHistory } as WeekInfo;
     });
     return mappedWeekInfo;
-  };
+  }, []);
 
-  const dayCardClickHandler = (weekday: weekdayKey) => {
+  const dayCardClickHandler = useCallback((weekday: weekdayKey) => {
     setSelectedDay(weekday);
-  };
+  }, []);
 
-  const previousWeekClickHandler = () => {
+  const previousWeekClickHandler = useCallback(() => {
     const startOfWeek = selectedWeek[0].fullDate;
     const endOfWeek = selectedWeek[6].fullDate;
 
     const previousWeek = getPreviousWeekRange({ startOfWeek, endOfWeek });
     setSelectedWeek(findLearningHistory(previousWeek.startOfWeek));
     setSelectedDay(7);
-  };
+  }, []);
 
-  const nextWeekClickHandler = () => {
+  const nextWeekClickHandler = useCallback(() => {
     const startOfWeek = selectedWeek[0].fullDate;
     const endOfWeek = selectedWeek[6].fullDate;
 
     const nextWeek = getNextWeekRange({ startOfWeek, endOfWeek });
     setSelectedWeek(findLearningHistory(nextWeek.startOfWeek));
     setSelectedDay(7);
-  };
+  }, []);
 
   useEffect(() => {
     const { startOfWeek, endOfWeek } = getCurrentWeekRange();

--- a/src/components/dashboard/main/WeeklyCalendar.tsx
+++ b/src/components/dashboard/main/WeeklyCalendar.tsx
@@ -5,7 +5,7 @@ import {
   getPreviousWeekRange,
   getFullWeekDate
 } from '@/src/util/day/getWeekRange';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type Props = {
   learning_history: LearningHistory[];
@@ -29,14 +29,20 @@ export default function WeeklyCalendar({ learning_history }: Props) {
     getFullWeekDate()
   );
   const [selectedDay, setSelectedDay] = useState<weekdayKey>(7);
+  const dayIdx = useRef(0);
 
   const findLearningHistory = useCallback((startOfWeek: string) => {
     const weekInfo = getFullWeekDate(startOfWeek);
+    const startIdx = dayIdx.current;
+    const slicedLearningHistory = learning_history.slice(startIdx);
 
     const mappedWeekInfo: WeekInfo[] = weekInfo.map((day) => {
-      const learningHistory = learning_history.find(
-        (history) => history.date === day.fullDate
-      );
+      const learningHistory = slicedLearningHistory.find((history, index) => {
+        if (history.date === day.fullDate) {
+          dayIdx.current = startIdx + index;
+          return true;
+        }
+      });
 
       return { ...day, learningHistory } as WeekInfo;
     });

--- a/src/components/dashboard/main/WeeklyCalendar.tsx
+++ b/src/components/dashboard/main/WeeklyCalendar.tsx
@@ -31,7 +31,6 @@ export default function WeeklyCalendar({ learning_history }: Props) {
   const [selectedDay, setSelectedDay] = useState<weekdayKey>(7);
 
   const findLearningHistory = useCallback((startOfWeek: string) => {
-    console.log('함수 실행!', startOfWeek);
     const weekInfo = getFullWeekDate(startOfWeek);
 
     const mappedWeekInfo: WeekInfo[] = weekInfo.map((day) => {

--- a/src/components/dashboard/main/WeeklyCalendar.tsx
+++ b/src/components/dashboard/main/WeeklyCalendar.tsx
@@ -54,7 +54,7 @@ export default function WeeklyCalendar({ learning_history }: Props) {
     const previousWeek = getPreviousWeekRange({ startOfWeek, endOfWeek });
     setSelectedWeek(findLearningHistory(previousWeek.startOfWeek));
     setSelectedDay(7);
-  }, []);
+  }, [selectedWeek]);
 
   const nextWeekClickHandler = useCallback(() => {
     const startOfWeek = selectedWeek[0].fullDate;
@@ -63,7 +63,7 @@ export default function WeeklyCalendar({ learning_history }: Props) {
     const nextWeek = getNextWeekRange({ startOfWeek, endOfWeek });
     setSelectedWeek(findLearningHistory(nextWeek.startOfWeek));
     setSelectedDay(7);
-  }, []);
+  }, [selectedWeek]);
 
   useEffect(() => {
     const { startOfWeek, endOfWeek } = getCurrentWeekRange();

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export default function Button({ className, children, onClick }: Props) {
   return (
-    <button onClick={onClick} className={`${className} btn`}>
+    <button onClick={onClick} className={`${className} btn rounded-none font-normal`}>
       {children}
     </button>
   );

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export default function Button({ className, children, onClick }: Props) {
   return (
-    <button onClick={onClick} className={`${className} btn rounded-none font-normal`}>
+    <button onClick={onClick} className={`${className} py-1 px-4 flex hover:opacity-90 active:focus:scale-95 transition-all items-center justify-center rounded-none`}>
       {children}
     </button>
   );

--- a/src/components/ui/lectureCard/HorizontalSmallLectureCard.tsx
+++ b/src/components/ui/lectureCard/HorizontalSmallLectureCard.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+
+type Props = {
+  src: string;
+  alt: string;
+  children: React.ReactNode;
+};
+
+export default function HorizontalSmallLectureCard({
+  src,
+  alt,
+  children
+}: Props) {
+  return (
+    <div className='w-[42rem] h-[11rem] bg-white drop-shadow-md flex p-3 gap-4'>
+      <div className='relative object-cover md:min-w-[calc(9rem*1.78)]'>
+        <Image fill={true} sizes='100%' src={src} alt={alt} />
+      </div>
+      <div className='w-full h-full'>{children}</div>
+    </div>
+  );
+}

--- a/src/util/day/getRelativeTime.ts
+++ b/src/util/day/getRelativeTime.ts
@@ -1,0 +1,10 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/ko';
+
+dayjs.locale('ko');
+dayjs.extend(relativeTime);
+
+export default function getRelativeTime(time: string) {
+  return dayjs(time).fromNow();
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -74,8 +74,10 @@ interface LatestLearningLecture {
   channel: string;
   thumbnail: string;
   course_title: string;
-  course_duration: number;
+  duration: number;
   last_view_time: string;
+  total_video_count: number;
+  completed_video_count: number;
   progress: number;
 }
 


### PR DESCRIPTION
## Motivation 🤔
- 대시보드에서 최근 학습 강의를 확인하고, 바로 학습에 들어갈 수 있도록 하기 위함

<br>

## Key changes ✅
- 디자인 시안을 바탕으로 최근 학습 강의 컴포넌트 구현
  - 제목은 2줄, 채널명은 1줄로 제한 _(초과시 ...로 대체)_
![image (1)](https://github.com/4m9d/sroom-fe/assets/63336701/f5312f47-6588-4f01-8849-d605e4f38998)
- 누적 수강 시간
  - API를 '분' 단위로 수정
  - 1000분 이상부터는 '시간' 단위로 표현 _(분 단위는 절삭)_
  - ex. `240` -> `240분` /  `1240` -> `20`시간
  <img width="260" alt="image" src="https://github.com/4m9d/sroom-fe/assets/63336701/94b68e08-3daa-4e98-b82a-70454cca26a0">
  <img width="260" alt="image" src="https://github.com/4m9d/sroom-fe/assets/63336701/d3d4e2f7-6bfa-4604-b44b-029a4526b057">


- `Button.tsx`
  - 디자인 수정 _(border-radius를 없앰)_
- `WeeklyCalendar.tsx`
  - `useCallback()`을 활용한 리렌더링 최적화 적용
  - `useRef()`를 활용한 `latest[]` _(학습 기록 데이터)_ 에서의 데이터 검색 최적화 적용

<br>

## To reviewers 🙏
- 마찬가지로, 폰트 크기나 컴포넌트 크기와 같은 부분은 전부 디자인 확정되면 수정할 예정입니다!
- 지금은 디자인 전체적인 느낌만 봐주세요...!