### PR TITLE
Feat/#31/#32/course enrollment dropdown(swm 216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gitignore 되어있는 환경변수 파일을 가장 상위(./sroom-fe)에 위�
 npm run dev
 ```
 
-❗️ **만약 개발 환경에서 Mock Server 대신 로컬 백엔드 서버(http://localhost:8080)를 이용하고 싶다면, 아래 코드로 구동해주시면 됩니다**
+❗️ **만약 개발 환경에서 Mock Server 대신 [로컬 백엔드 서버](http://localhost:8080)를 이용하고 싶다면, 아래 코드로 구동해주시면 됩니다**
 
 ```bash
 npm run dev:local

--- a/public/icon/icon_lecture.svg
+++ b/public/icon/icon_lecture.svg
@@ -1,0 +1,4 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 6.00002L4.5 8.16509L4.5 3.83496L8 6.00002Z" fill="#AAAAAA"/>
+<rect x="0.5" y="1.5" width="11" height="9" stroke="#AAAAAA" stroke-linejoin="round"/>
+</svg>

--- a/public/icon/icon_time.svg
+++ b/public/icon/icon_time.svg
@@ -1,0 +1,4 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="6" cy="6" r="5.5" stroke="#AAAAAA"/>
+<path d="M6 3V6.5H9" stroke="#AAAAAA" stroke-linecap="square"/>
+</svg>

--- a/src/components/dashboard/latestLearning/LatestLearningCourseCard.tsx
+++ b/src/components/dashboard/latestLearning/LatestLearningCourseCard.tsx
@@ -44,7 +44,8 @@ export default function LatestLearningCourseCard({ course }: Props) {
                 width={12}
                 height={12}
               />
-              {course.completed_video_count.toLocaleString()}개 /
+              {course.completed_video_count.toLocaleString()}개
+              <span>/</span>
               {course.total_video_count.toLocaleString()}개 완료
             </p>
             <div className='flex items-center'>

--- a/src/components/dashboard/latestLearning/LatestLearningCourseCard.tsx
+++ b/src/components/dashboard/latestLearning/LatestLearningCourseCard.tsx
@@ -4,6 +4,7 @@ import HorizontalSmallLectureCard from '../../ui/lectureCard/HorizontalSmallLect
 import Button from '../../ui/button/Button';
 import getFormattedHour from '@/src/util/day/getFormattedHour';
 import getTimeInMinute from '@/src/util/day/getTimeInMinute';
+import Image from 'next/image';
 
 type Props = {
   course: Course;
@@ -26,11 +27,25 @@ export default function LatestLearningCourseCard({ course }: Props) {
         </div>
         <div className='flex justify-between h-10 gap-5 mb-1'>
           <div className='flex flex-col justify-between flex-1 gap-1 py-1'>
-            <p className='text-xs text-zinc-500'>
-              총 강의 시간 :{' '}
-              {getFormattedHour(getTimeInMinute(course.duration))} | 수강한
-              영상 : {course.completed_video_count.toLocaleString()}개 /{' '}
-              {course.total_video_count.toLocaleString()}개
+            <p className='flex text-xs text-zinc-500'>
+              <Image
+                className='mr-1'
+                src={'/icon/icon_time.svg'}
+                alt='총 강의 시간'
+                width={12}
+                height={12}
+              />
+              {getFormattedHour(getTimeInMinute(course.duration))}
+              <span className='mx-2 text-zinc-300'>|</span>
+              <Image
+                className='mr-1'
+                src={'/icon/icon_lecture.svg'}
+                alt='수강한 영상'
+                width={12}
+                height={12}
+              />
+              {course.completed_video_count.toLocaleString()}개 /
+              {course.total_video_count.toLocaleString()}개 완료
             </p>
             <div className='flex items-center'>
               <ProgressBar

--- a/src/components/dashboard/latestLearning/LatestLearningCourseCard.tsx
+++ b/src/components/dashboard/latestLearning/LatestLearningCourseCard.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ProgressBar from '../../ui/ProgressBar';
 import HorizontalSmallLectureCard from '../../ui/lectureCard/HorizontalSmallLectureCard';
 import Button from '../../ui/button/Button';
+import getFormattedHour from '@/src/util/day/getFormattedHour';
+import getTimeInMinute from '@/src/util/day/getTimeInMinute';
 
 type Props = {
   course: Course;
@@ -25,8 +27,10 @@ export default function LatestLearningCourseCard({ course }: Props) {
         <div className='flex justify-between h-10 gap-5 mb-1'>
           <div className='flex flex-col justify-between flex-1 gap-1 py-1'>
             <p className='text-xs text-zinc-500'>
-              총 강의 시간 : {course.duration.toLocaleString()}분 | 수강한 영상 :{' '}
-              {course.completed_video_count.toLocaleString()}개 / {course.total_video_count.toLocaleString()}개
+              총 강의 시간 :{' '}
+              {getFormattedHour(getTimeInMinute(course.duration))} | 수강한
+              영상 : {course.completed_video_count.toLocaleString()}개 /{' '}
+              {course.total_video_count.toLocaleString()}개
             </p>
             <div className='flex items-center'>
               <ProgressBar

--- a/src/components/dashboard/main/TotalLearningTime.tsx
+++ b/src/components/dashboard/main/TotalLearningTime.tsx
@@ -1,3 +1,4 @@
+import getTimeInMinute from '@/src/util/day/getTimeInMinute';
 import { useCallback, useMemo } from 'react';
 
 type Props = {
@@ -19,7 +20,7 @@ export default function TotalLearningTime({ time }: Props) {
   }, []);
 
   const [timeInString, timeUnit] = useMemo(
-    () => timeUnitHandler(time),
+    () => timeUnitHandler(getTimeInMinute(time)),
     [time, timeUnitHandler]
   );
 

--- a/src/components/dashboard/main/WeeklyCalendar.tsx
+++ b/src/components/dashboard/main/WeeklyCalendar.tsx
@@ -126,6 +126,7 @@ export default function WeeklyCalendar({ learning_histories }: Props) {
           );
         })}
         <button
+          type='button'
           onClick={previousWeekClickHandler}
           className='absolute flex items-center justify-center w-10 h-10 font-bold transition-all hover:bg-zinc-200 -left-14 top-5'
         >
@@ -133,6 +134,7 @@ export default function WeeklyCalendar({ learning_histories }: Props) {
         </button>
         {getCurrentWeekRange().startOfWeek !== selectedWeek[0].fullDate && (
           <button
+            type='button'
             onClick={nextWeekClickHandler}
             className='absolute flex items-center justify-center w-10 h-10 font-bold transition-all hover:bg-zinc-200 -right-14 top-5'
           >

--- a/src/components/dashboard/main/WeeklyCalendar.tsx
+++ b/src/components/dashboard/main/WeeklyCalendar.tsx
@@ -14,14 +14,14 @@ type Props = {
 };
 
 const weekdayList = {
-  0: 'S',
-  1: 'M',
-  2: 'T',
-  3: 'W',
-  4: 'T',
-  5: 'F',
-  6: 'S',
-  7: 'NONE'
+  '0': 'S',
+  '1': 'M',
+  '2': 'T',
+  '3': 'W',
+  '4': 'T',
+  '5': 'F',
+  '6': 'S',
+  '7': 'NONE'
 } as const;
 
 type weekdayKey = keyof typeof weekdayList;
@@ -30,7 +30,7 @@ export default function WeeklyCalendar({ learning_histories }: Props) {
   const [selectedWeek, setSelectedWeek] = useState<WeekInfo[]>(
     getFullWeekDate()
   );
-  const [selectedDay, setSelectedDay] = useState<weekdayKey>(7);
+  const [selectedDay, setSelectedDay] = useState<weekdayKey>('7');
 
   const findLearningHistory = useCallback((startOfWeek: string) => {
     const weekInfo = getFullWeekDate(startOfWeek);
@@ -58,7 +58,7 @@ export default function WeeklyCalendar({ learning_histories }: Props) {
 
     const previousWeek = getPreviousWeekRange({ startOfWeek, endOfWeek });
     setSelectedWeek(findLearningHistory(previousWeek.startOfWeek));
-    setSelectedDay(7);
+    setSelectedDay('7');
   }, [selectedWeek]);
 
   const nextWeekClickHandler = useCallback(() => {
@@ -67,7 +67,7 @@ export default function WeeklyCalendar({ learning_histories }: Props) {
 
     const nextWeek = getNextWeekRange({ startOfWeek, endOfWeek });
     setSelectedWeek(findLearningHistory(nextWeek.startOfWeek));
-    setSelectedDay(7);
+    setSelectedDay('7');
   }, [selectedWeek]);
 
   useEffect(() => {
@@ -119,7 +119,7 @@ export default function WeeklyCalendar({ learning_histories }: Props) {
           return (
             <DayCard
               key={day.fullDate + index}
-              weekday={index as weekdayKey}
+              weekday={index.toString() as weekdayKey}
               date={day.date}
               hasValue={day.learningHistory !== undefined}
             />

--- a/src/components/dashboard/main/WeeklyCalendar.tsx
+++ b/src/components/dashboard/main/WeeklyCalendar.tsx
@@ -5,7 +5,9 @@ import {
   getPreviousWeekRange,
   getFullWeekDate
 } from '@/src/util/day/getWeekRange';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import getFormattedHour from '@/src/util/day/getFormattedHour';
+import { useCallback, useEffect, useState } from 'react';
+import getTimeInMinute from '@/src/util/day/getTimeInMinute';
 
 type Props = {
   learning_histories: LearningHistory[];
@@ -168,7 +170,12 @@ export default function WeeklyCalendar({ learning_histories }: Props) {
             <>
               <LearningHistoryItem
                 title={'학습 시간'}
-                value={`${selectedWeek[selectedDay].learningHistory?.learning_time}분`}
+                value={getFormattedHour(
+                  getTimeInMinute(
+                    selectedWeek[selectedDay].learningHistory?.learning_time ??
+                      0
+                  )
+                )}
               />
               <LearningHistoryItem
                 title={'푼 퀴즈'}

--- a/src/components/lectureDetail/LectureDetailCard.tsx
+++ b/src/components/lectureDetail/LectureDetailCard.tsx
@@ -30,9 +30,9 @@ export default function LectureDetailCard({ lectureDetail }: Props) {
     <HorizontalBigLectureCard src={thumbnail} alt={lecture_title}>
       <div className='flex flex-col justify-start h-[calc(100%-3rem)]'>
         <div className='flex flex-col gap-1 mt-4 md:mb-1 lg:mb-2'>
-          <p className='text-base font-bold whitespace-normal line-clamp-1 xl:line-clamp-2'>
+          <h2 className='text-base font-bold whitespace-normal line-clamp-1 xl:line-clamp-2'>
             {lecture_title}
-          </p>
+          </h2>
           <p className='text-sm font-semibold whitespace-normal text-zinc-500 line-clamp-1'>
             {channel}
           </p>

--- a/src/components/lectureDetail/LectureDetailCard.tsx
+++ b/src/components/lectureDetail/LectureDetailCard.tsx
@@ -1,9 +1,9 @@
-import {
-  THUMBNAIL_PREVIEW_HEIGHT,
-  THUMBNAIL_PREVIEW_MIN_WIDTH
-} from '@/src/constants/ui/thumbnail';
-import Image from 'next/image';
-import React from 'react';
+import getCompactFormattedDate from '@/src/util/day/getCompactFormattedDate';
+import HorizontalBigLectureCard from '../ui/lectureCard/HorizontalBigLectureCard';
+import StarRatingWithReviewCount from '../ui/rating/StarRatingWithReviewCount';
+import ThumbnailBadge from '../ui/ThumbnailBadge';
+import getCompactFormattedNumber from '@/src/util/number/getCompactFormattedNumber';
+import Button from '../ui/button/Button';
 
 type Props = {
   lectureDetail: LectureDetail;
@@ -11,66 +11,68 @@ type Props = {
 
 export default function LectureDetailCard({ lectureDetail }: Props) {
   const {
-    thumbnail,
+    lecture_code,
     lecture_title,
-    rating,
+    published_at,
+    view_count,
+    lecture_count,
+    thumbnail,
     channel,
-    review_count,
     description,
+    rating,
+    review_count,
     is_playlist,
     is_enrolled
   } = lectureDetail;
 
-  <div
-    className={`flex w-full cursor-pointer ${THUMBNAIL_PREVIEW_HEIGHT.MEDIUM} ${THUMBNAIL_PREVIEW_HEIGHT.LARGE} ${THUMBNAIL_PREVIEW_HEIGHT.XLARGE}`}
-  >
-    <div
-      className={`relative object-cover ${THUMBNAIL_PREVIEW_MIN_WIDTH.MEDIUM} ${THUMBNAIL_PREVIEW_MIN_WIDTH.LARGE} ${THUMBNAIL_PREVIEW_MIN_WIDTH.XLARGE}`}
-    >
-      <Image fill={true} sizes='100%' src={thumbnail} alt={lecture_title} />
-    </div>
-    <div className='flex flex-col w-1/2 px-4'>
-      <p className='font-semibold h-1/5 sm:text-sm lg:text-base sm:line-clamp-1 lg:line-clamp-2'>
-        {lecture_title}
-      </p>
-      <div className='flex items-center mb-1 h-1/6'>
-        <input className='mr-1 bg-orange-300 sm:w-3 sm:h-3 lg:w-4 lg:h-4 mask mask-star-2' />
-        <p className='sm:text-xs lg:text-sm'>{rating}</p>
-      </div>
-      <div className='flex items-center justify-start sm:text-xs lg:text-sm opacity-80 h-1/6'>
-        <p className='max-w-[50%] line-clamp-1'>{channel}</p>
-        <span className='ml-2 sm:text-xs lg:text-sm badge sm:badge-sm lg:badge-md badge-outline'>{`리뷰 ${review_count}개`}</span>
-      </div>
-      <p className='mt-1 sm:text-xs lg:text-sm h-1/2 opacity-80 sm:line-clamp-3 lg:line-clamp-5'>
-        {description}
-      </p>
-    </div>
-  </div>;
   return (
-    <div
-      className={`flex w-full cursor-pointer ${THUMBNAIL_PREVIEW_HEIGHT.MEDIUM} ${THUMBNAIL_PREVIEW_HEIGHT.LARGE} ${THUMBNAIL_PREVIEW_HEIGHT.XLARGE}`}
-    >
-      <div
-        className={`relative object-cover ${THUMBNAIL_PREVIEW_MIN_WIDTH.MEDIUM} ${THUMBNAIL_PREVIEW_MIN_WIDTH.LARGE} ${THUMBNAIL_PREVIEW_MIN_WIDTH.XLARGE}`}
-      >
-        <Image fill={true} sizes='100%' src={thumbnail} alt={lecture_title} />
-      </div>
-      <div className='flex flex-col w-1/2 px-4'>
-        <p className='font-semibold h-1/5 sm:text-sm lg:text-base sm:line-clamp-1 lg:line-clamp-2'>
-          {lecture_title}
-        </p>
-        <div className='flex items-center mb-1 h-1/6'>
-          <input className='mr-1 bg-orange-300 sm:w-3 sm:h-3 lg:w-4 lg:h-4 mask mask-star-2' />
-          <p className='sm:text-xs lg:text-sm'>{rating}</p>
+    <HorizontalBigLectureCard src={thumbnail} alt={lecture_title}>
+      <div className='flex flex-col justify-start h-full'>
+        <div className='flex flex-col gap-1 mt-4 md:mb-1 lg:mb-2'>
+          <p className='text-base font-bold whitespace-normal line-clamp-1 xl:line-clamp-2'>
+            {lecture_title}
+          </p>
+          <p className='text-sm font-semibold whitespace-normal text-zinc-500 line-clamp-1'>
+            {channel}
+          </p>
+          <p className='text-xs text-zinc-500'>
+            {is_playlist
+              ? `영상 ${lecture_count?.toLocaleString()}개`
+              : `조회수 ${getCompactFormattedNumber(view_count)}회`}
+            ･{getCompactFormattedDate(published_at)}
+          </p>
         </div>
-        <div className='flex items-center justify-start sm:text-xs lg:text-sm opacity-80 h-1/6'>
-          <p className='max-w-[50%] line-clamp-1'>{channel}</p>
-          <span className='ml-2 sm:text-xs lg:text-sm badge sm:badge-sm lg:badge-md badge-outline'>{`리뷰 ${review_count}개`}</span>
+        <div className='flex flex-col justify-between h-full'>
+          <div className='min-h-[3rem] whitespace-pre-wrap'>
+            <p className='text-sm text-zinc-500 line-clamp-2 xl:line-clamp-5'>
+              {description}
+            </p>
+          </div>
+          <Button className='w-full h-12 font-semibold text-zinc-200 bg-zinc-800'>
+            {is_enrolled ? '수강하러 가기' : '등록하기'}
+          </Button>
         </div>
-        <p className='mt-1 sm:text-xs lg:text-sm h-1/2 opacity-80 sm:line-clamp-3 lg:line-clamp-5'>
-          {description}
-        </p>
       </div>
-    </div>
+      <div className='absolute right-3 top-3'>
+        <StarRatingWithReviewCount
+          rating={rating}
+          review_count={review_count}
+        />
+      </div>
+      {is_enrolled && (
+        <div className='absolute top-3 left-3'>
+          <ThumbnailBadge title='수강 중' className='bg-zinc-800' />
+        </div>
+      )}
+      {is_playlist && (
+        <div
+          className={`absolute top-3 ${
+            is_enrolled ? 'left-[4.7rem]' : 'left-3'
+          }`}
+        >
+          <ThumbnailBadge title='재생목록' className='bg-orange-500' />
+        </div>
+      )}
+    </HorizontalBigLectureCard>
   );
 }

--- a/src/components/lectureDetail/LectureDetailCard.tsx
+++ b/src/components/lectureDetail/LectureDetailCard.tsx
@@ -3,7 +3,7 @@ import HorizontalBigLectureCard from '../ui/lectureCard/HorizontalBigLectureCard
 import StarRatingWithReviewCount from '../ui/rating/StarRatingWithReviewCount';
 import ThumbnailBadge from '../ui/ThumbnailBadge';
 import getCompactFormattedNumber from '@/src/util/number/getCompactFormattedNumber';
-import Button from '../ui/button/Button';
+import LectureDetailEnrollmentButton from './LectureDetailEnrollmentButton';
 
 type Props = {
   lectureDetail: LectureDetail;
@@ -21,13 +21,14 @@ export default function LectureDetailCard({ lectureDetail }: Props) {
     description,
     rating,
     review_count,
+    courses,
     is_playlist,
     is_enrolled
   } = lectureDetail;
 
   return (
     <HorizontalBigLectureCard src={thumbnail} alt={lecture_title}>
-      <div className='flex flex-col justify-start h-full'>
+      <div className='flex flex-col justify-start h-[calc(100%-3rem)]'>
         <div className='flex flex-col gap-1 mt-4 md:mb-1 lg:mb-2'>
           <p className='text-base font-bold whitespace-normal line-clamp-1 xl:line-clamp-2'>
             {lecture_title}
@@ -42,17 +43,13 @@ export default function LectureDetailCard({ lectureDetail }: Props) {
             ･{getCompactFormattedDate(published_at)}
           </p>
         </div>
-        <div className='flex flex-col justify-between h-full'>
-          <div className='min-h-[3rem] whitespace-pre-wrap'>
-            <p className='text-sm text-zinc-500 line-clamp-2 xl:line-clamp-5'>
-              {description}
-            </p>
-          </div>
-          <Button className='w-full h-12 font-semibold text-zinc-200 bg-zinc-800'>
-            {is_enrolled ? '수강하러 가기' : '등록하기'}
-          </Button>
+        <div className='h-full whitespace-pre-wrap'>
+          <p className='text-sm text-zinc-500 line-clamp-2 xl:line-clamp-5'>
+            {description}
+          </p>
         </div>
       </div>
+      <LectureDetailEnrollmentButton is_enrolled={is_enrolled} is_playlist={is_playlist} courses={courses}/>
       <div className='absolute right-3 top-3'>
         <StarRatingWithReviewCount
           rating={rating}

--- a/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
+++ b/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
@@ -19,7 +19,7 @@ export default function LectureDetailEnrollmentButton({
 
   const LIST__LI = 'px-3 border-b cursor-pointer border-b-gray-200';
   const LIST__DIV =
-    'flex items-center justify-center h-12 text-sm font-semibold rounded-none text-zinc-500 hover:text-inherit';
+    'flex items-center justify-center h-12 text-sm font-semibold rounded-none text-zinc-500 hover:text-inherit focus:text-inherit';
 
   const EnrolledCoursesList = ({
     courses,
@@ -53,15 +53,15 @@ export default function LectureDetailEnrollmentButton({
           <div className={LIST__DIV}>새 강의 코스 등록하기</div>
         </li>
         <li className={`${LIST__LI} !border-b-0 group`}>
-          <div className={`${LIST__DIV} peer relative`}>
+          <button
+            className={`${LIST__DIV} w-full peer relative`}
+          >
             기존 강의 코스에 추가하기{' '}
             <span className='ml-2 transition-all group-hover:rotate-90'>
               〉
             </span>
-          </div>
-          <div
-            className='absolute right-0 hidden w-4/5 pt-5 bg-transparent top-full group-hover:block hover:block dropdown-content'
-          >
+          </button>
+          <div className='absolute right-0 hidden w-4/5 pt-5 bg-transparent top-full group-hover:block hover:block peer-focus-within:block'>
             <ul className='relative bg-white border border-gray-200'>
               <EnrolledCoursesList
                 courses={courses}

--- a/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
+++ b/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
@@ -1,0 +1,113 @@
+import Button from '../ui/button/Button';
+
+type Props = {
+  is_enrolled: boolean;
+  is_playlist: boolean;
+  courses: EnrolledCourse[];
+};
+
+export default function LectureDetailEnrollmentButton({
+  is_enrolled,
+  is_playlist,
+  courses
+}: Props) {
+  const buttonTitle = is_enrolled
+    ? '수강하러 가기'
+    : is_playlist
+    ? '등록하기'
+    : '코스에 추가하기';
+
+  const LIST__LI = 'px-3 border-b cursor-pointer border-b-gray-200';
+  const LIST__DIV =
+    'flex items-center justify-center h-12 text-sm font-semibold rounded-none text-zinc-500 hover:text-inherit';
+
+  const EnrolledCoursesList = ({
+    courses,
+    className
+  }: {
+    courses: EnrolledCourse[];
+    className?: string;
+  }) => {
+    return (
+      <>
+        {courses.map((course) => (
+          <li
+            className={`${className} ${LIST__LI} w-full`}
+            key={course.course_id}
+          >
+            <div className={`${LIST__DIV} px-2`}>
+              <span className='whitespace-normal line-clamp-1'>
+                {course.course_title}
+              </span>
+            </div>
+          </li>
+        ))}
+      </>
+    );
+  };
+
+  const PlaylistEnrollment = ({ courses }: { courses: EnrolledCourse[] }) => {
+    return (
+      <>
+        <li className={LIST__LI}>
+          <div className={LIST__DIV}>새 강의 코스 등록하기</div>
+        </li>
+        <li className={`${LIST__LI} !border-b-0 group`}>
+          <div className={`${LIST__DIV} peer relative`}>
+            기존 강의 코스에 추가하기{' '}
+            <span className='ml-2 transition-all group-hover:rotate-90'>
+              〉
+            </span>
+          </div>
+          <div
+            className='absolute right-0 hidden pt-5 bg-transparent top-full group-hover:block hover:block w-80 dropdown-content'
+          >
+            <ul className='relative bg-white border border-gray-200'>
+              <EnrolledCoursesList
+                courses={courses}
+                className={'peer hover:bg-orange-500 hover:text-zinc-100'}
+              />
+              <span className='peer-first-of-type:peer-hover:bg-orange-500 absolute -top-[0.3px] w-3 h-3 rotate-45 -translate-x-1/2 -translate-y-1/2 border-t bg-white border-l left-10 border-l-gray-200 border-t-gray-200' />
+            </ul>
+          </div>
+        </li>
+      </>
+    );
+  };
+
+  const VideoEnrollment = ({ courses }: { courses: EnrolledCourse[] }) => {
+    return (
+      <>
+        <EnrolledCoursesList courses={courses} />
+        <li className='flex items-center justify-center gap-2 px-3 cursor-pointer hover:bg-orange-500 hover:text-zinc-100'>
+          <div className='flex items-center justify-center w-5 h-5 rounded-full shrink-0 bg-zinc-700 text-zinc-100'>
+            +
+          </div>
+          <div className='flex items-center justify-center h-12 text-sm font-semibold rounded-none'>
+            새로운 코스 생성하기
+          </div>
+        </li>
+      </>
+    );
+  };
+
+  return (
+    <div className='w-full dropdown dropdown-hover !z-[60]'>
+      <Button className='w-full h-12 font-semibold peer text-zinc-200 bg-zinc-800'>
+        {buttonTitle}
+      </Button>
+      {is_enrolled === false && (
+        <div className='w-full pt-5 dropdown-content'>
+          <ul className='relative bg-white border border-gray-200'>
+            <span className='absolute -top-[0.3px] w-3 h-3 rotate-45 -translate-x-1/2 -translate-y-1/2 border-t bg-white border-l left-10 border-l-gray-200 border-t-gray-200' />
+            {is_playlist ? (
+              <PlaylistEnrollment courses={courses} />
+            ) : (
+              <VideoEnrollment courses={courses} />
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
+++ b/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
@@ -57,9 +57,9 @@ export default function LectureDetailEnrollmentButton({
             className={`${LIST__DIV} w-full peer relative`}
           >
             기존 강의 코스에 추가하기{' '}
-            <span className='ml-2 transition-all group-hover:rotate-90'>
+            <button type='button' className='ml-2 transition-all group-hover:rotate-90'>
               〉
-            </span>
+            </button>
           </button>
           <div className='absolute right-0 hidden w-4/5 pt-5 bg-transparent top-full group-hover:block hover:block peer-focus-within:block'>
             <ul className='relative bg-white border border-gray-200'>

--- a/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
+++ b/src/components/lectureDetail/LectureDetailEnrollmentButton.tsx
@@ -60,7 +60,7 @@ export default function LectureDetailEnrollmentButton({
             </span>
           </div>
           <div
-            className='absolute right-0 hidden pt-5 bg-transparent top-full group-hover:block hover:block w-80 dropdown-content'
+            className='absolute right-0 hidden w-4/5 pt-5 bg-transparent top-full group-hover:block hover:block dropdown-content'
           >
             <ul className='relative bg-white border border-gray-200'>
               <EnrolledCoursesList

--- a/src/components/lectureDetail/LectureDetailHeading.tsx
+++ b/src/components/lectureDetail/LectureDetailHeading.tsx
@@ -6,7 +6,9 @@ type Props = {
 export default function LectureDetailHeading({ title, children }: Props) {
   return (
     <div className='flex my-10 text-xl font-bold border-b-2 border-black border-solid'>
+      <h3>
       {title}
+      </h3>
       {children}
     </div>
   );

--- a/src/components/lectureDetail/LectureDetailHeading.tsx
+++ b/src/components/lectureDetail/LectureDetailHeading.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-
 type Props = {
   title: string;
+  children?: React.ReactNode;
 };
 
-export default function LectureDetailHeading({ title }: Props) {
+export default function LectureDetailHeading({ title, children }: Props) {
   return (
-    <div className='my-10 text-xl border-b-2 border-black border-solid'>
+    <div className='flex my-10 text-xl font-bold border-b-2 border-black border-solid'>
       {title}
+      {children}
     </div>
   );
 }

--- a/src/components/lectureDetail/LectureDetailModal.tsx
+++ b/src/components/lectureDetail/LectureDetailModal.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/src/constants/lectureDetail/lectureDetail';
 import LectureDetailHeading from './LectureDetailHeading';
 import LectureDetailReviewSkeleton from './review/LectureDetailReviewSkeleton';
+import OneStar from '../ui/rating/OneStar';
 
 type Props = {
   lectureDetail: LectureDetail;
@@ -23,7 +24,7 @@ export default function LectureDetailModal({
   lectureDetail,
   navigationType
 }: Props) {
-  const { is_playlist, lecture_code } = lectureDetail;
+  const { is_playlist, lecture_code, rating } = lectureDetail;
   const router = useRouter();
   const onCloseHandler =
     navigationType === 'soft' ? router.back : () => router.replace('/');
@@ -33,7 +34,7 @@ export default function LectureDetailModal({
   return (
     <Modal
       id='modal'
-      className='relative h-full rounded-none scroll-smooth'
+      className='relative h-full !p-14 rounded-none scroll-smooth'
       onClose={onCloseHandler}
     >
       <LectureDetailCard lectureDetail={lectureDetail} />
@@ -59,7 +60,12 @@ export default function LectureDetailModal({
         )}
       </section>
       <section id='reviews'>
-        <LectureDetailHeading title={'후기'} />
+        <LectureDetailHeading title={'후기'}>
+          <div className='flex items-center justify-center ml-2 mr-1'>
+            <OneStar className='w-5 h-5' />
+            <p className='font-semibold text-orange-500'>{rating}</p>
+          </div>
+        </LectureDetailHeading>
         <Suspense
           fallback={
             <LectureDetailReviewSkeleton

--- a/src/components/lectureDetail/LectureDetailTabNav.tsx
+++ b/src/components/lectureDetail/LectureDetailTabNav.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import TabNav from '../ui/TabNav';
 import { useEffect, useState } from 'react';
 import useIntersectionObserver from '@/src/hooks/useIntersectionObserver';
-import { ROOT_MARGIN } from '@/src/constants/modal/modal';
 
 type Props = {
   is_playlist: boolean;
@@ -15,7 +14,6 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
   );
   const [observe, unobserve] = useIntersectionObserver(
     setActiveId,
-    ROOT_MARGIN,
     document.getElementById('modal')
   );
   useEffect(() => {
@@ -26,7 +24,7 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
   }, []);
 
   return (
-    <TabNav className='sticky z-10 h-16 mb-5 tab-bordered -top-8 bg-inherit'>
+    <TabNav className='sticky z-10 h-16 mb-5 tab-bordered -top-14 bg-inherit'>
       {is_playlist && (
         <li>
           <Link
@@ -34,8 +32,8 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
             replace={true}
             scroll={false}
             shallow={true}
-            className={`tab tab-bordered ${
-              activeId === 'indexes' ? 'tab-active' : 'border-none'
+            className={`tab tab-bordered text-lg transition-colors ${
+              activeId === 'indexes' ? 'tab-active font-bold' : 'border-none font-semibold'
             }`}
           >
             목차
@@ -48,8 +46,8 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
           replace={true}
           scroll={false}
           shallow={true}
-          className={`tab tab-bordered ${
-            activeId === 'reviews' ? 'tab-active' : 'border-none'
+          className={`tab tab-bordered text-lg transition-colors ${
+            activeId === 'reviews' ? 'tab-active font-bold' : 'border-none font-semibold'
           }`}
         >
           후기

--- a/src/components/lectureDetail/index/LectureDetailIndexCard.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexCard.tsx
@@ -1,20 +1,34 @@
 'use client';
+import getCompactFormattedTime from '@/src/util/day/getCompactFormattedTime';
 import Image from 'next/image';
 import React from 'react';
 
 type Props = {
   lectureIndex: LectureIndex;
+  indexNum: number;
 };
 
-export default function LectureDetailIndexCard({ lectureIndex }: Props) {
+export default function LectureDetailIndexCard({
+  lectureIndex,
+  indexNum
+}: Props) {
   const { thumbnail, lecture_title, duration } = lectureIndex;
   return (
-    <li className='flex items-center justify-between h-20 px-4 bg-zinc-50'>
-      <div className='relative object-cover min-w-[calc(4rem*1.78)] h-full'>
+    <li className='flex items-center justify-between h-20 p-3 border border-gray-200 bg-zinc-50'>
+      <div className='relative object-cover min-w-[calc(4rem*1.78)] h-16 border-gray-200 border'>
         <Image fill={true} sizes='100%' src={thumbnail} alt={lecture_title} />
       </div>
-      <div className='text-sm font-semibold'>{lecture_title}</div>
-      <div className='text-sm'>{duration}</div>
+      <div className='flex items-center w-full gap-5 px-5'>
+        <div className='flex items-center justify-center w-6 h-6 rounded-full shrink-0 bg-zinc-700'>
+          <p className='text-sm font-semibold text-zinc-100'>{indexNum}</p>
+        </div>
+        <div className='text-sm font-semibold xl:text-base line-clamp-2'>
+          <p>{lecture_title}</p>
+        </div>
+      </div>
+      <div className='text-xs text-zinc-500'>
+        <p>{getCompactFormattedTime(duration)}</p>
+      </div>
     </li>
   );
 }

--- a/src/components/lectureDetail/index/LectureDetailIndexCard.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexCard.tsx
@@ -20,7 +20,7 @@ export default function LectureDetailIndexCard({
       </div>
       <div className='flex items-center w-full gap-5 px-5'>
         <div className='flex items-center justify-center w-6 h-6 rounded-full shrink-0 bg-zinc-700'>
-          <p className='text-sm font-semibold text-zinc-100'>{indexNum}</p>
+          <span className='text-sm font-semibold text-zinc-100'>{indexNum}</span>
         </div>
         <div className='text-sm font-semibold xl:text-base line-clamp-2'>
           <p>{lecture_title}</p>

--- a/src/components/lectureDetail/index/LectureDetailIndexList.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexList.tsx
@@ -59,12 +59,13 @@ export default async function LectureDetailIndexList({
   );
   return (
     <>
-      <ul className='grid grid-cols-1 gap-y-4'>
+      <ul className='grid grid-cols-1 gap-4'>
         {data?.pages.map((page) =>
-          page?.index_list?.map((lectureIndex) => (
+          page?.index_list?.map((lectureIndex, idx) => (
             <LectureDetailIndexCard
               key={lectureIndex.index}
               lectureIndex={lectureIndex}
+              indexNum={idx + 1}
             />
           ))
         )}

--- a/src/components/lectureDetail/index/LectureDetailIndexSkeleton.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexSkeleton.tsx
@@ -13,7 +13,7 @@ const LectureDetailIndexSkeleton = ({ limit, indexPageRef }: Props) => {
 
   const StyledSkeleton = () => {
     return (
-      <li className={'flex items-center justify-between h-20 w-full px-4'}>
+      <li className={'flex items-center justify-between h-20'}>
         <div className='w-full h-full'>
           <Skeleton height='100%' />
         </div>
@@ -21,7 +21,7 @@ const LectureDetailIndexSkeleton = ({ limit, indexPageRef }: Props) => {
     );
   };
   return (
-    <ul className='grid grid-cols-1 gap-y-4'>
+    <ul className='grid grid-cols-1 gap-4'>
       {skeletonArray.map((idx) => (
         <StyledSkeleton key={'skeleton' + idx} />
       ))}

--- a/src/components/lectureDetail/review/LectureDetailReviewCard.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewCard.tsx
@@ -1,4 +1,8 @@
 'use client';
+
+import getCompactDateFormat from "@/src/util/day/getCompactFormattedDate";
+import FiveStars from "../../ui/rating/FiveStars";
+
 type Props = {
   lectureReview: LectureReview;
 };
@@ -12,16 +16,21 @@ export default function LectureDetailReviewCard({ lectureReview }: Props) {
     submitted_rating
   } = lectureReview;
   return (
-    <li className='flex flex-col items-start justify-center py-10 border-b-2 border-solid min-h-16 bg-base-100'>
-      <div className='flex mb-5'>
-        <div>{submitted_rating}</div>
-        <span className='mr-1'>{reviewer_name}</span>
+    <li className='p-3 border border-gray-200 min-h-16'>
+      <div className='flex justify-between mb-5'>
         <div>
-          <span className='mr-1'>{published_at}</span>
+          <FiveStars
+            className='w-3 h-3 bg-zinc-800'
+            rating={submitted_rating}
+          />
+          <span className='ml-2 text-sm'>{reviewer_name}</span>
+        </div>
+        <div className='text-sm text-zinc-500'>
+          {getCompactDateFormat(published_at)}
         </div>
       </div>
-      <div className='flex'>
-        <p>{review_content}</p>
+      <div className='whitespace-pre-wrap'>
+        <p className='overflow-auto text-sm text-zinc-500'>{review_content}</p>
       </div>
     </li>
   );

--- a/src/components/lectureDetail/review/LectureDetailReviewList.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewList.tsx
@@ -65,7 +65,7 @@ export default async function LectureDetailReviewList({
 
   return (
     <>
-      <ul className='grid grid-cols-1'>
+      <ul className='grid grid-cols-1 gap-4'>
         {data?.pages.map((page) =>
           page?.map((lectureReview) => (
             <LectureDetailReviewCard
@@ -76,7 +76,9 @@ export default async function LectureDetailReviewList({
         )}
       </ul>
       <div className='flex justify-center my-10 mb-20'>
-        {hasNextPage ? <LoadMoreButton title='후기 더보기' onClick={fetchNextPage} /> : null}
+        {hasNextPage ? (
+          <LoadMoreButton title='후기 더보기' onClick={fetchNextPage} />
+        ) : null}
       </div>
     </>
   );

--- a/src/components/lectureDetail/review/LectureDetailReviewSkeleton.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewSkeleton.tsx
@@ -13,7 +13,7 @@ const LectureDetailReviewSkeleton = ({ limit, reviewPageRef }: Props) => {
 
   const StyledSkeleton = () => {
     return (
-      <li className={'flex flex-col h-16'}>
+      <li className={'flex flex-col h-40'}>
         <div className='w-full h-full'>
           <Skeleton height='100%' />
         </div>
@@ -21,7 +21,7 @@ const LectureDetailReviewSkeleton = ({ limit, reviewPageRef }: Props) => {
     );
   };
   return (
-    <ul className='grid grid-cols-1 gap-y-1'>
+    <ul className='grid grid-cols-1 gap-4'>
       {skeletonArray.map((idx) => (
         <StyledSkeleton key={'skeleton' + idx} />
       ))}

--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -33,7 +33,7 @@ export default function NavBar({ logo, profileDropdown }: Props) {
         >
           <p>로그아웃</p>
         </Button>
-        <button className={`${hidden} dropdown dropdown-hover`}>
+        <button type='button' className={`${hidden} dropdown dropdown-hover`}>
           <div
             tabIndex={0}
             className='flex flex-col items-start w-44 btn btn-ghost rounded-btn'

--- a/src/components/recommendations/LectureRecommendationsCard.tsx
+++ b/src/components/recommendations/LectureRecommendationsCard.tsx
@@ -1,4 +1,4 @@
-import StarRatingWithReviewCount from '../ui/StarRatingWithReviewCount';
+import StarRatingWithReviewCount from '../ui/rating/StarRatingWithReviewCount';
 import ThumbnailBadge from '../ui/ThumbnailBadge';
 import VerticalSmallLectureCard from '../ui/lectureCard/VerticalSmallLectureCard';
 

--- a/src/components/recommendations/LectureRecommendationsList.tsx
+++ b/src/components/recommendations/LectureRecommendationsList.tsx
@@ -50,15 +50,14 @@ export default function LectureRecommendationsList({ recommendations }: Props) {
             swiper.isBeginning ? setIsFirstSlide(true) : setIsFirstSlide(false);
           }}
         >
-          <ul>
-            {recommendations.map((lecture) => (
-              <li key={lecture.lecture_code}>
-                <SwiperSlide className='!flex justify-center'>
-                  <LectureRecommendationsCard lecture={lecture} />
-                </SwiperSlide>
-              </li>
-            ))}
-          </ul>
+          {recommendations.map((lecture) => (
+            <SwiperSlide
+              key={lecture.lecture_code}
+              className='!flex justify-center'
+            >
+              <LectureRecommendationsCard lecture={lecture} />
+            </SwiperSlide>
+          ))}
         </Swiper>
         {!isFirstSlide && (
           <AnimatePresence>

--- a/src/components/recommendations/LectureRecommendationsList.tsx
+++ b/src/components/recommendations/LectureRecommendationsList.tsx
@@ -50,14 +50,15 @@ export default function LectureRecommendationsList({ recommendations }: Props) {
             swiper.isBeginning ? setIsFirstSlide(true) : setIsFirstSlide(false);
           }}
         >
-          {recommendations.map((lecture) => (
-            <SwiperSlide
-              className='!flex justify-center'
-              key={lecture.lecture_code}
-            >
-              <LectureRecommendationsCard lecture={lecture} />
-            </SwiperSlide>
-          ))}
+          <ul>
+            {recommendations.map((lecture) => (
+              <li key={lecture.lecture_code}>
+                <SwiperSlide className='!flex justify-center'>
+                  <LectureRecommendationsCard lecture={lecture} />
+                </SwiperSlide>
+              </li>
+            ))}
+          </ul>
         </Swiper>
         {!isFirstSlide && (
           <AnimatePresence>

--- a/src/components/search/SearchLectureCard.tsx
+++ b/src/components/search/SearchLectureCard.tsx
@@ -1,9 +1,9 @@
 'use client';
 import getRelativeTime from '@/src/util/day/getRelativeTime';
 import HorizontalSmallLectureCard from '../ui/lectureCard/HorizontalSmallLectureCard';
-import StarRatingWithReviewCount from '../ui/StarRatingWithReviewCount';
+import StarRatingWithReviewCount from '../ui/rating/StarRatingWithReviewCount';
 import ThumbnailBadge from '../ui/ThumbnailBadge';
-import getCompactNumberFormat from '@/src/util/number/getCompactNumberFormat';
+import getCompactFormattedNumber from '@/src/util/number/getCompactFormattedNumber';
 
 export default async function SearchLectureCard({
   lecture
@@ -38,7 +38,7 @@ export default async function SearchLectureCard({
           <p className='text-xs text-zinc-500'>
             {is_playlist
               ? `영상 ${lecture_count?.toLocaleString()}개`
-              : `조회수 ${getCompactNumberFormat(view_count)}회`}
+              : `조회수 ${getCompactFormattedNumber(view_count)}회`}
             ･{getRelativeTime(published_at)}
           </p>
         </div>

--- a/src/components/search/SearchLectureCard.tsx
+++ b/src/components/search/SearchLectureCard.tsx
@@ -38,7 +38,7 @@ export default async function SearchLectureCard({
           <p className='text-xs text-zinc-500'>
             {is_playlist
               ? `영상 ${lecture_count?.toLocaleString()}개`
-              : `조회수 ${getCompactNumberFormat(view_count as number)}회`}
+              : `조회수 ${getCompactNumberFormat(view_count)}회`}
             ･{getRelativeTime(published_at)}
           </p>
         </div>
@@ -48,7 +48,7 @@ export default async function SearchLectureCard({
           </p>
         </div>
       </div>
-      <div className='absolute top-3 -right-3'>
+      <div className='absolute right-3 top-3'>
         <StarRatingWithReviewCount
           rating={rating}
           review_count={review_count}

--- a/src/components/search/SearchResultsSkeleton.tsx
+++ b/src/components/search/SearchResultsSkeleton.tsx
@@ -1,8 +1,4 @@
 'use client';
-import {
-  THUMBNAIL_PREVIEW_HEIGHT,
-  THUMBNAIL_PREVIEW_MIN_WIDTH
-} from '@/src/constants/ui/thumbnail';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -10,7 +10,7 @@ type Props = {
 export default function Modal({ id, className, children, onClose }: Props) {
   return (
     <AnimatePresence>
-      <div className={'modal modal-open'}>
+      <div className={'modal modal-open overflow-x-hidden'}>
         <div onClick={onClose} className='modal-backdrop' />
         <motion.div
           id={id}
@@ -18,7 +18,7 @@ export default function Modal({ id, className, children, onClose }: Props) {
           initial={{ opacity: 0, scale: 0.97 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.97 }}
-          className={`px-12 py-7 modal-box min-w-[70vw] ${className}`}
+          className={`px-12 py-7 modal-box min-w-[70vw] max-w-[70vw] ${className}`}
         >
           <button
             onClick={onClose}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -21,6 +21,7 @@ export default function Modal({ id, className, children, onClose }: Props) {
           className={`px-12 py-7 modal-box min-w-[70vw] max-w-[70vw] ${className}`}
         >
           <button
+            type='button'
             onClick={onClose}
             className='absolute btn btn-sm btn-circle btn-ghost right-2 top-2'
           >

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -16,7 +16,12 @@ export default function Toast({ toast }: { toast: CustomToast }) {
         initial={{ y: 200 }}
         animate={{ y: 0 }}
         exit={{ y: 200 }}
-        transition={{ repeat: 1, repeatType: 'reverse', repeatDelay: TOAST_DELAY }}
+        transition={{
+          repeat: 1,
+          repeatType: 'reverse',
+          repeatDelay: TOAST_DELAY
+        }}
+        role='alert'
         className={`fixed alert h-14 flex items-center ${
           type === 'error' ? 'alert-error' : 'alert-success'
         } z-10 bottom-16 w-1/2 left-1/4`}

--- a/src/components/ui/button/SwiperNavigationButton.tsx
+++ b/src/components/ui/button/SwiperNavigationButton.tsx
@@ -11,6 +11,7 @@ export default function SwiperNavigationButton({
 }: Props) {
   return (
     <button
+      type='button'
       onClick={onClick}
       className={`${className} flex justify-center items-center w-12 h-12 text-2xl font-bold text-white btn btn-ghost bg-zinc-300 opacity-70 rounded-full`}
     >

--- a/src/components/ui/lectureCard/HorizontalBigLectureCard.tsx
+++ b/src/components/ui/lectureCard/HorizontalBigLectureCard.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+
+type Props = {
+  src: string;
+  alt: string;
+  children: React.ReactNode;
+};
+
+export default function HorizontalBigLectureCard({
+  src,
+  alt,
+  children
+}: Props) {
+  return (
+    <div className='relative flex w-full gap-5 p-3 bg-white lg:gap-8'>
+      <div className='relative object-cover min-w-[calc(7rem*1.78)] lg:min-w-[calc(12rem*1.78)] xl:min-w-[calc(19rem*1.78)] min-h-[7rem] lg:min-h-[12rem] xl:min-h-[19rem]'>
+        <Image fill={true} sizes='100%' src={src} alt={alt} />
+      </div>
+      <div className='w-full min-h-full'>{children}</div>
+    </div>
+  );
+}

--- a/src/components/ui/lectureCard/HorizontalSmallLectureCard.tsx
+++ b/src/components/ui/lectureCard/HorizontalSmallLectureCard.tsx
@@ -12,7 +12,7 @@ export default function HorizontalSmallLectureCard({
   children
 }: Props) {
   return (
-    <div className='relative w-[42rem] h-[11rem] bg-white drop-shadow-md flex p-3 gap-4'>
+    <div className='border-gray-200 border relative w-[42rem] h-[11rem] bg-white flex p-3 gap-4'>
       <div className='relative object-cover md:min-w-[calc(9rem*1.78)]'>
         <Image fill={true} sizes='100%' src={src} alt={alt} />
       </div>

--- a/src/components/ui/rating/FiveStars.tsx
+++ b/src/components/ui/rating/FiveStars.tsx
@@ -1,0 +1,52 @@
+'use client';
+type Props = {
+  className?: string;
+  isInputEnabled?: boolean;
+  ref?: React.MutableRefObject<string>;
+  rating?: number;
+};
+
+export default function FiveStars({
+  className,
+  isInputEnabled = false,
+  ref,
+  rating
+}: Props) {
+  const ratingOnChangeHandler = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const rating = event.target.value;
+    if (ref) {
+      ref.current = rating;
+    }
+  };
+
+  const checkedHandler = (index: number) => {
+    if (ref) {
+      return ref.current === index.toString();
+    }
+    return rating === index;
+  }
+
+  return (
+    <div
+      className={`rating ${
+        isInputEnabled === false && 'pointer-events-none'
+      }`}
+    >
+      {new Array(5).fill(0).map((_, index) => {
+        return (
+          <input
+            onChange={ratingOnChangeHandler}
+            key={index}
+            type='radio'
+            name={`rating-${ref ? ref.current : rating}`}
+            value={index + 1}
+            className={`${className} bg-orange-500 mask mask-star-2`}
+            checked={checkedHandler(index + 1)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/rating/OneStar.tsx
+++ b/src/components/ui/rating/OneStar.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  className?: string;
+};
+
+export default function OneStar({ className }: Props) {
+  return (
+      <input
+        className={`${className} bg-orange-500 mb-[0.1rem] mr-[0.1rem] mask mask-star-2 pointer-events-none`}
+      />
+  );
+}

--- a/src/components/ui/rating/StarRatingWithReviewCount.tsx
+++ b/src/components/ui/rating/StarRatingWithReviewCount.tsx
@@ -1,3 +1,5 @@
+import OneStar from "./OneStar";
+
 type Props = {
   rating: number;
   review_count: number;
@@ -5,10 +7,11 @@ type Props = {
 
 export default function StarRatingWithReviewCount({rating, review_count}: Props) {
   return (
-    <div className='flex w-24 h-1'>
-      <p className='mr-1 text-xs font-bold text-orange-500'>
-        ★ {rating}
-      </p>
+    <div className='flex max-w-[6.5rem] h-4'>
+      <div className='flex items-center justify-center mr-1'>
+        <OneStar className='w-3 h-3' />
+        <p className='text-xs font-bold text-orange-500'>{rating}</p>
+      </div>
       <p className='text-xs font-bold text-orange-500 underline'>
         후기 {review_count.toLocaleString()}개
       </p>

--- a/src/constants/modal/modal.ts
+++ b/src/constants/modal/modal.ts
@@ -1,2 +1,0 @@
-// intersection observer
-export const ROOT_MARGIN = `0px 0px`

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -2,13 +2,13 @@ import { useCallback, useRef } from 'react';
 
 export default function useIntersectionObserver(
   setId: (id: string) => void,
-  rootMargin: string,
-  root: HTMLElement | null
+  root: HTMLElement | null,
+  rootMargin?: string
 ) {
   const option = {
     threshold: 0,
-    rootMargin,
-    root
+    root,
+    rootMargin
   };
 
   const checkIntersect = useCallback(

--- a/src/util/day/getCompactFormattedDate.ts
+++ b/src/util/day/getCompactFormattedDate.ts
@@ -1,0 +1,8 @@
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
+
+dayjs.locale('ko');
+
+export default function getCompactDateFormat(date: string) {
+  return dayjs(date).format('YYYY.MM.DD');
+}

--- a/src/util/day/getCompactFormattedTime.ts
+++ b/src/util/day/getCompactFormattedTime.ts
@@ -1,0 +1,17 @@
+export default function getCompactFormattedDuration(time: number) {
+  const hour = Math.floor(time / 3600).toString();
+  const minute = Math.floor((time % 3600) / 60).toString();
+  const second = Math.floor((time % 3600) % 60).toString();
+  let timeFormat = [];
+
+  if (hour !== '0') {
+    timeFormat.push(hour.padStart(2, '0'));
+  }
+  if (minute !== '0') {
+    timeFormat.push(minute.padStart(2, '0'));
+  }
+  if (second !== '0') {
+    timeFormat.push(second.padStart(2, '0'));
+  }
+  return timeFormat.join(':');
+}

--- a/src/util/day/getFormattedHour.ts
+++ b/src/util/day/getFormattedHour.ts
@@ -1,0 +1,13 @@
+export default function getFormattedHour(time: number) {
+  const hour = Math.floor(time / 60);
+  const minute = time % 60;
+  let hourFormat = [];
+
+  if (hour > 0) {
+    hourFormat.push(`${hour}시간`);
+  }
+  if (minute > 0) {
+    hourFormat.push(`${minute}분`);
+  }
+  return hourFormat.join(' ');
+}

--- a/src/util/day/getTimeInMinute.ts
+++ b/src/util/day/getTimeInMinute.ts
@@ -1,0 +1,3 @@
+export default function getTimeInMinute(time: number) {
+  return Math.floor(time / 60);
+}

--- a/src/util/number/getCompactFormattedNumber.ts
+++ b/src/util/number/getCompactFormattedNumber.ts
@@ -1,4 +1,4 @@
-export default function getCompactNumberFormat(number: number) {
+export default function getCompactFormattedNumber(number: number) {
   return new Intl.NumberFormat('ko-KR', {
     notation: 'compact',
     maximumFractionDigits: 1

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -180,6 +180,10 @@ interface LectureReview {
 
 type LectureReviewList = LectureReview[];
 
+type EnrolledCourse = {
+  [key in 'course_id' | 'course_title' | 'total_video_count']: Course[key];
+};
+
 interface LectureDetail extends Lecture {
   published_at: string;
   view_count: number;
@@ -187,6 +191,7 @@ interface LectureDetail extends Lecture {
   lecture_count?: number;
   indexes?: LectureIndexList;
   reviews: LectureReview[];
+  courses: EnrolledCourse[];
 }
 
 interface LectureIndexParams extends Record<string, string | number | boolean> {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -161,18 +161,17 @@ interface LectureIndex {
   index: number;
   thumbnail: string;
   lecture_title: string;
-  duration: string;
+  duration: number;
 }
 
 interface LectureIndexList {
   index_list: LectureIndex[];
   next_page_token: string | null;
-  total_duration: string;
+  total_duration: number;
 }
 
 interface LectureReview {
   index: number;
-  review_title: string;
   review_content: string;
   submitted_rating: number;
   reviewer_name: string;
@@ -184,7 +183,7 @@ type LectureReviewList = LectureReview[];
 interface LectureDetail extends Lecture {
   published_at: string;
   view_count: number;
-  duration: string;
+  duration: number;
   lecture_count?: number;
   indexes?: LectureIndexList;
   reviews: LectureReview[];

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -69,7 +69,7 @@ interface LoginResponse extends Response, Profile {
 ////////////////////////////////dashboards///////////////////////////////
 
 interface Course {
-  course_id: string;
+  course_id: number;
   channels: string;
   thumbnail: string;
   course_title: string;


### PR DESCRIPTION
## Motivation 🤔
- 강의 상세 모달에서 등록하기 버튼 및 드롭다운 UI 구현
- 강의 상세 모달 디자인 레이아웃 수정

<br>

## Key changes ✅
### 강의 등록 버튼
- 재생목록 강의일 때
![ezgif com-crop (2)](https://github.com/4m9d/sroom-fe/assets/63336701/8cc97a18-1265-4010-bb6d-22258d2553df)
- 단일 영상 강의일 때
![ezgif com-crop (1)](https://github.com/4m9d/sroom-fe/assets/63336701/e9e91116-eafa-4892-ab75-957d5dbd2dda)
- 이미 수강 중인 강의일 때 (_추후 수강 화면으로 navigate 구현 예정)_
<img width="835" alt="image" src="https://github.com/4m9d/sroom-fe/assets/63336701/8e08378a-436f-4e03-87a6-48e8436fae24">

### 강의 상세 모달 레이아웃 수정
- 목차
  <img width="809" alt="image" src="https://github.com/4m9d/sroom-fe/assets/63336701/d603dd5b-e282-4ed9-8e57-4e1500b93011">
- 후기
  <img width="809" alt="image" src="https://github.com/4m9d/sroom-fe/assets/63336701/b5b0b113-54f7-4053-b7ca-061b17892f17">

<br>

## To reviewers 🙏
- 기존 레이아웃 수정과 마찬가지로, 화면 너비에 따른 크기 조정이 완벽하게 되지 않았어요! 나중에 찐 디자인 수정 때 반영하겠습니다
- 색상이나 레이아웃 위치에 관한 피드백 부탁드립니다