### PR TITLE
Feat/#31/#36/enrollment success toast(swm 219)

### DIFF
--- a/public/icon/icon_lecture_white.svg
+++ b/public/icon/icon_lecture_white.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M14 9.5L8.75 12.5311L8.75 6.46891L14 9.5Z" fill="white"/>
+  <rect x="2" y="3" width="17" height="13" stroke="white" stroke-width="1.5" stroke-linejoin="round"/>
+</svg>

--- a/src/api/Endpoints.ts
+++ b/src/api/Endpoints.ts
@@ -4,6 +4,7 @@ export const Endpoints = {
   MEMBERS: `${API_URL}/members`,
   DASHBOARDS: `${API_URL}/dashboards`,
   LECTURES: `${API_URL}/lectures`,
+  COURSES: `${API_URL}/courses`,
 } as const;
 
 type Endpoints = (typeof Endpoints)[keyof typeof Endpoints];

--- a/src/api/ErrorMessage.ts
+++ b/src/api/ErrorMessage.ts
@@ -7,6 +7,7 @@ export const ErrorMessage = {
   DETAIL_INDEX: '강의 목차를 불러오지 못했어요',
   DETAIL_REVIEW: '강의 후기를 불러오지 못했어요',
   RECOMMENDATIONS: '추천 강의를 불러오지 못했어요',
+  ENROLLMENT: '강의 등록에 실패했어요',
 } as const;
 
 type ErrorMessage = (typeof ErrorMessage)[keyof typeof ErrorMessage];

--- a/src/api/courses/courses.ts
+++ b/src/api/courses/courses.ts
@@ -1,0 +1,39 @@
+import getQueryURL from '@/src/util/http/getQueryURL';
+import { Endpoints } from '../Endpoints';
+import { ErrorMessage } from '../ErrorMessage';
+import { getAuthorizedHeaders } from '@/src/util/http/getAuthorizedHeaders';
+
+export async function enrollLectureInNewCourse(params: EnrollLectureInNewCourseParams) {
+  const headers = await getAuthorizedHeaders();
+  const body = JSON.stringify(params.body);
+  return await fetch(getQueryURL(Endpoints.COURSES, params.query), {
+    method: 'POST',
+    headers,
+    body
+  }).then(async (res) => {
+    if (res.ok) {
+      return (await res.json()) as Promise<EnrollLectureResponse>;
+    } else {
+      return Promise.reject(new Error(ErrorMessage.ENROLLMENT));
+    }
+  });
+}
+
+export async function enrollLectureInExistingCourse(
+  course_id: number,
+  params: EnrollLectureInExistingCourseParams
+) {
+  const headers = await getAuthorizedHeaders();
+  const body = JSON.stringify(params);
+  return await fetch(getQueryURL(`${Endpoints.COURSES}/${course_id}`), {
+    method: 'POST',
+    headers,
+    body
+  }).then(async (res) => {
+    if (res.ok) {
+      return (await res.json()) as Promise<EnrollLectureResponse>;
+    } else {
+      return Promise.reject(new Error(ErrorMessage.ENROLLMENT));
+    }
+  });
+}

--- a/src/app/@modal/(.)search/[lecture_code]/error.tsx
+++ b/src/app/@modal/(.)search/[lecture_code]/error.tsx
@@ -1,5 +1,5 @@
 'use client';
-import setErrorToast from '@/src/util/error/setErrorToast';
+import setErrorToast from '@/src/util/toast/setErrorToast';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect } from 'react';
-import setErrorToast from '../../util/error/setErrorToast';
+import setErrorToast from '../../util/toast/setErrorToast';
 
 export default function Error({
   error,

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect } from 'react';
-import setErrorToast from '../util/error/setErrorToast';
+import setErrorToast from '../util/toast/setErrorToast';
 
 export default function GlobalError({
   error,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,6 @@ export default function RootLayout({ children, modal }: Props) {
   return (
     <html lang='en'>
       <body className={inter.className}>
-        <div id='toast'></div>
           <AuthSessionProvider>
             <QueryProvider>
               <NavBar
@@ -33,7 +32,7 @@ export default function RootLayout({ children, modal }: Props) {
               />
               {children}
               {modal}
-              <Toaster/>
+            <Toaster containerStyle={{zIndex: 9999}}/>
             </QueryProvider>
           </AuthSessionProvider>
       </body>

--- a/src/app/search/[lecture_code]/error.tsx
+++ b/src/app/search/[lecture_code]/error.tsx
@@ -1,5 +1,5 @@
 'use client';
-import setErrorToast from '@/src/util/error/setErrorToast';
+import setErrorToast from '@/src/util/toast/setErrorToast';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 

--- a/src/app/search/loading.tsx
+++ b/src/app/search/loading.tsx
@@ -1,7 +1,0 @@
-type Props = {}
-
-export default function loading({}: Props) {
-  return (
-    null
-  )
-}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 import { fetchLectureRecommendations } from '@/src/api/lectures/search';
-import { QueryKeys } from '@/src/api/queryKeys';
 import LectureRecommendationsList from '@/src/components/recommendations/LectureRecommendationsList';
 import SearchResultsHeading from '@/src/components/search/SearchResultsHeading';
 import SearchResultsList from '@/src/components/search/SearchResultsList';
 import SearchResultsSkeleton from '@/src/components/search/SearchResultsSkeleton';
 import { LIMIT_PER_FETCH } from '@/src/constants/search/search';
-import { useQuery } from '@tanstack/react-query';
 import { Suspense, useRef } from 'react';
 
 type Props = {
@@ -14,6 +12,8 @@ type Props = {
 };
 
 export default async function SearchResults({ searchParams }: Props) {
+  const searchResultPageRef = useRef<number>(0);
+
   const requestParam: SearchLectureParams = {
     keyword:
       searchParams.keyword === undefined
@@ -23,13 +23,9 @@ export default async function SearchResults({ searchParams }: Props) {
     next_page_token: '',
     filter: searchParams.filter ? searchParams.filter : 'all'
   };
-
-  const { data } = useQuery(
-    [QueryKeys.RECCOMENDATION],
-    fetchLectureRecommendations
-  );
-
-  const searchResultPageRef = useRef<number>(0);
+  
+  const recommendations = await fetchLectureRecommendations();
+  const recommendedLectures = recommendations.recommendations;
 
   return (
     <>
@@ -51,8 +47,8 @@ export default async function SearchResults({ searchParams }: Props) {
           </Suspense>
         </section>
       </div>
-      {data?.recommendations && (
-        <LectureRecommendationsList recommendations={data?.recommendations} />
+      {recommendations && (
+        <LectureRecommendationsList recommendations={recommendedLectures} />
       )}
     </>
   );

--- a/src/components/lectureDetail/LectureDetailCard.tsx
+++ b/src/components/lectureDetail/LectureDetailCard.tsx
@@ -7,9 +7,10 @@ import LectureEnrollmentButton from '../lectureEnrollment/LectureEnrollmentButto
 
 type Props = {
   lectureDetail: LectureDetail;
+  onClose: () => void;
 };
 
-export default function LectureDetailCard({ lectureDetail }: Props) {
+export default function LectureDetailCard({ lectureDetail, onClose }: Props) {
   const {
     lecture_code,
     lecture_title,
@@ -49,7 +50,13 @@ export default function LectureDetailCard({ lectureDetail }: Props) {
           </p>
         </div>
       </div>
-      <LectureEnrollmentButton is_enrolled={is_enrolled} is_playlist={is_playlist} courses={courses}/>
+      <LectureEnrollmentButton
+        onEnrollSuccess={onClose}
+        is_enrolled={is_enrolled}
+        is_playlist={is_playlist}
+        courses={courses}
+        lecture_code={lectureDetail.lecture_code}
+      />
       <div className='absolute right-3 top-3'>
         <StarRatingWithReviewCount
           rating={rating}

--- a/src/components/lectureDetail/LectureDetailModal.tsx
+++ b/src/components/lectureDetail/LectureDetailModal.tsx
@@ -30,15 +30,15 @@ export default function LectureDetailModal({
 }: Props) {
   const { is_playlist, lecture_code, rating } = lectureDetail;
   const router = useRouter();
+  const indexPageRef = useRef<number>(0);
+  const reviewPageRef = useRef<number>(0);
+
   const onCloseHandler = useMemo(() => {
-    return navigationType === 'soft' ? router.back : () => router.replace('/');
+    return navigationType === 'soft' ? router.back : () => router.replace('/dashboard');
   }, [navigationType, router]);
   const isTheOnlyModalInPage = () => {
     return document.querySelectorAll('dialog[open]').length === 1;
   };
-
-  const indexPageRef = useRef<number>(0);
-  const reviewPageRef = useRef<number>(0);
 
   useEffect(() => {
     const modal = document.getElementById(
@@ -66,7 +66,10 @@ export default function LectureDetailModal({
         className='relative h-full p-14 rounded-none scroll-smooth min-w-[70vw] max-w-[70vw]'
         onClose={onCloseHandler}
       >
-        <LectureDetailCard lectureDetail={lectureDetail} />
+        <LectureDetailCard
+          lectureDetail={lectureDetail}
+          onClose={onCloseHandler}
+        />
         <LectureDetailTabNav is_playlist={is_playlist} />
         <section id='indexes'>
           {is_playlist && (
@@ -112,8 +115,13 @@ export default function LectureDetailModal({
       </Modal>
       <LectureEnrollmentModal
         onClose={() => closeModalHandler('LECTURE_ENROLLMENT')}
+        onEnrollSuccess={onCloseHandler}
       />
-      <SchedulingModal lectureDetail={lectureDetail} onClose={() => closeModalHandler('SCHEDULING')} />
+      <SchedulingModal
+        lectureDetail={lectureDetail}
+        onClose={() => closeModalHandler('SCHEDULING')}
+        onEnrollSuccess={onCloseHandler}
+      />
     </>
   );
 }

--- a/src/components/lectureDetail/index/LectureDetailIndexList.tsx
+++ b/src/components/lectureDetail/index/LectureDetailIndexList.tsx
@@ -10,7 +10,7 @@ import {
   STALE_TIME
 } from '@/src/constants/lectureDetail/lectureDetail';
 import LoadMoreButton from '../../ui/button/LoadMoreButton';
-import setErrorToast from '@/src/util/error/setErrorToast';
+import setErrorToast from '@/src/util/toast/setErrorToast';
 
 export default async function LectureDetailIndexList({
   lectureCode,

--- a/src/components/lectureDetail/review/LectureDetailReviewList.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewList.tsx
@@ -10,7 +10,7 @@ import {
   REVIEW_LIMIT
 } from '@/src/constants/lectureDetail/lectureDetail';
 import LectureDetailReviewCard from './LectureDetailReviewCard';
-import setErrorToast from '@/src/util/error/setErrorToast';
+import setErrorToast from '@/src/util/toast/setErrorToast';
 
 export default async function LectureDetailReviewList({
   lectureCode,

--- a/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
+++ b/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
@@ -1,4 +1,5 @@
 'use cleint';
+import Image from 'next/image';
 import Button from '../ui/button/Button';
 import { showModalHandler } from '@/src/util/modal/modalHandler';
 
@@ -38,10 +39,20 @@ export default function LectureEnrollmentButton({
             className={`${className} ${LIST__LI} w-full`}
             key={course.course_id}
           >
-            <div role='button' className={`${LIST__DIV} px-2`}>
-              <span className='whitespace-normal line-clamp-1'>
+            <div role='button' className={`${LIST__DIV} px-2 justify-center gap-2`}>
+              <span className='max-w-[70%] whitespace-normal line-clamp-1'>
                 {course.course_title}
               </span>
+              <div className='flex'>
+                <Image
+                  className='w-auto h-auto mr-1'
+                  src={'/icon/icon_lecture.svg'}
+                  alt='등록된 영상'
+                  width={12}
+                  height={12}
+                />
+                <span className='text-xs text-zinc-500'>{course.total_video_count}</span>
+              </div>
             </div>
           </li>
         ))}

--- a/src/components/lectureEnrollment/SchedulingModal.tsx
+++ b/src/components/lectureEnrollment/SchedulingModal.tsx
@@ -47,7 +47,8 @@ export default function SchedulingModal({ lectureDetail, onClose }: Props) {
   const expectedDate = getFormattedExpectedDate();
 
   function getFormattedExpectedDate() {
-    const expectedDate = getCurrentDate().add(scheduling.length, 'week');
+    const expectedDuration = Math.floor(durationInMinutes / inputValue);
+    const expectedDate = getCurrentDate().add(expectedDuration, 'day');
 
     return [expectedDate.year(), expectedDate.month() + 1, expectedDate.date()];
   }
@@ -95,7 +96,7 @@ export default function SchedulingModal({ lectureDetail, onClose }: Props) {
     controls.set('initial');
     controls.start('animate');
   }, [inputValue, controls]);
-  
+
   return (
     <Modal
       id={ModalIDs.SCHEDULING}

--- a/src/components/search/SearchResultsList.tsx
+++ b/src/components/search/SearchResultsList.tsx
@@ -6,7 +6,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import SearchLectureCard from './SearchLectureCard';
 import Link from 'next/link';
 import LoadMoreButton from '../ui/button/LoadMoreButton';
-import setErrorToast from '@/src/util/error/setErrorToast';
+import setErrorToast from '@/src/util/toast/setErrorToast';
 import { ErrorMessage } from '@/src/api/ErrorMessage';
 import { CACHE_TIME, STALE_TIME } from '@/src/constants/search/search';
 import Button from '../ui/button/Button';
@@ -38,14 +38,10 @@ export default async function SearchResultsList({
 
     updateSearchResultPageRef(next_page_token);
 
-    return await fetchLecturesByKeyword(params)
-      .then((res) => {
-        return res;
-      })
-      .catch(() => {
-        setErrorToast(new Error(ErrorMessage.SEARCH));
-        return null;
-      });
+    return await fetchLecturesByKeyword(params).catch(() => {
+      setErrorToast(new Error(ErrorMessage.SEARCH));
+      return null;
+    });
   };
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(

--- a/src/components/ui/LoadingSpinner.tsx
+++ b/src/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+type Props = {
+  className?: string;
+}
+
+export default function LoadingSpinner({
+  className
+}: Props) {
+  return <span className={`${className} loading loading-spinner`}></span>;
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,11 +1,13 @@
 'use client';
 import { TOAST_DELAY } from '@/src/constants/ui/toast';
 import { AnimatePresence, motion } from 'framer-motion';
+import Button from './button/Button';
+import Image from 'next/image';
 
-const Emoji = {
-  success: '✅',
+const Emoji: Emoji = {
+  lecture_enrollment: '🤓',
   error: '🚫'
-} as const;
+};
 
 export default function Toast({ toast }: { toast: CustomToast }) {
   const { type, title, description, buttonLabel, buttonOnClick } = toast;
@@ -22,24 +24,50 @@ export default function Toast({ toast }: { toast: CustomToast }) {
           repeatDelay: TOAST_DELAY
         }}
         role='alert'
-        className={`fixed alert h-14 flex items-center ${
-          type === 'error' ? 'alert-error' : 'alert-success'
-        } z-10 bottom-16 w-1/2 left-1/4`}
+        className={`fixed h-24 flex !z-[9999] w-[88%] md:w-[88%] lg:w-[60%] px-7 py-6 justify-between  md:bottom-10 lg:bottom-14 left-[calc(6%)] lg:left-[20%] items-center gap-5 shadow-lg ${
+          type === 'error'
+            ? 'bg-red-400'
+            : type === 'lecture_enrollment'
+            ? 'bg-white'
+            : ''
+        }`}
       >
-        <div className='flex items-center justify-between'>
-          <p className='text-sm font-bold'>
+        <div className='flex items-center gap-7 shrink-0'>
+          <p className='text-xl font-bold'>
             <span className='inline-block mr-2 align-middle'>
               {Emoji[type]}
             </span>
             {title}
           </p>
-          <div className='ml-10'>
-            <p className='text-xs'>{description}</p>
-          </div>
+          <p
+            className={`text-sm ${
+              type === 'error'
+                ? 'text-black'
+                : type === 'lecture_enrollment'
+                ? 'text-zinc-500'
+                : ''
+            }`}
+          >
+            {description}
+          </p>
+        </div>
+        <div className='w-[12rem] h-12 text-white'>
           {buttonLabel && buttonOnClick && (
-            <button onClick={buttonOnClick} className='btn btn-sm btn-ghost'>
-              {buttonLabel}
-            </button>
+            <Button
+              onClick={buttonOnClick}
+              className='flex items-center justify-center !px-7 !py-4 w-full h-full bg-orange-500'
+            >
+              {type === 'lecture_enrollment' && (
+                <Image
+                  className='w-auto h-auto mr-3'
+                  src={'/icon/icon_lecture_white.svg'}
+                  alt='재생 버튼'
+                  width={20}
+                  height={20}
+                />
+              )}
+              <span className='text-sm font-bold'>{buttonLabel}</span>
+            </Button>
           )}
         </div>
       </motion.div>

--- a/src/components/ui/button/Button.tsx
+++ b/src/components/ui/button/Button.tsx
@@ -2,11 +2,13 @@ type Props = {
   className?: string;
   children?: React.ReactNode;
   onClick?: () => void;
+  disabled?: boolean;
 };
 
-export default function Button({ className, children, onClick }: Props) {
+export default function Button({ className, children, onClick, disabled }: Props) {
   return (
     <button
+      disabled={disabled}
       onClick={onClick}
       className={`${className} h-12 py-1 px-4 flex hover:opacity-90 active:focus:scale-95 transition-all items-center justify-center rounded-none`}
     >

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { QueryKeys } from '../api/queryKeys';
 import { ErrorMessage } from '../api/ErrorMessage';
 import { ONE_MINUTE_IN_MS } from '../constants/auth/auth';
-import setErrorToast from '../util/error/setErrorToast';
+import setErrorToast from '../util/toast/setErrorToast';
 
 export default function useAuth() {
   const router = useRouter();

--- a/src/util/day/getCompactFormattedDate.ts
+++ b/src/util/day/getCompactFormattedDate.ts
@@ -3,6 +3,9 @@ import 'dayjs/locale/ko';
 
 dayjs.locale('ko');
 
-export default function getCompactDateFormat(date: string) {
-  return dayjs(date).format('YYYY.MM.DD');
+export default function getCompactDateFormat(
+  date: string,
+  format: '.' | '-' = '.'
+) {
+  return dayjs(date).format(`YYYY${format}MM${format}DD`);
 }

--- a/src/util/toast/setErrorToast.ts
+++ b/src/util/toast/setErrorToast.ts
@@ -1,8 +1,8 @@
 import toast from 'react-hot-toast';
-import ErrorToast from '../../components/ui/Toast';
+import Toast from '../../components/ui/Toast';
 import { TOAST_TIMEOUT } from '../../constants/ui/toast';
 
-export default function setErrorToast(error : Error) {
+export default function setErrorToast(error: Error) {
   const errorToast: CustomToast = {
     type: 'error',
     title: '에러 발생',
@@ -12,8 +12,12 @@ export default function setErrorToast(error : Error) {
     toast: errorToast
   };
 
-  toast.custom(() => ErrorToast(param), {
+  toast.custom(() => Toast(param), {
     duration: TOAST_TIMEOUT,
-    position: 'bottom-center'
+    position: 'bottom-center',
+    ariaProps: {
+      role: 'alert',
+      'aria-live': 'assertive'
+    }
   });
 }

--- a/src/util/toast/setLectureEnrollToast.ts
+++ b/src/util/toast/setLectureEnrollToast.ts
@@ -1,0 +1,26 @@
+import toast from 'react-hot-toast';
+import Toast from '../../components/ui/Toast';
+import { TOAST_TIMEOUT } from '../../constants/ui/toast';
+
+export default function setLectureEnrollToast() {
+  const lectureEnrollToast: CustomToast = {
+    type: 'lecture_enrollment',
+    title: '강의가 등록됐어요!',
+    description: '지금 바로 수강을 시작해보세요',
+    buttonLabel: '수강하러 가기',
+    buttonOnClick: () => {}
+  };
+  const param = {
+    toast: lectureEnrollToast
+  };
+
+  toast.custom(() => Toast(param), {
+    id: 'lecture_enrollment',
+    duration: TOAST_TIMEOUT,
+    position: 'bottom-center',
+    ariaProps: {
+      role: 'status',
+      'aria-live': 'polite'
+    }
+  });
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -213,3 +213,33 @@ interface LectureRecommendations {
 }
 
 /////////////////////////////////////////////////////////////////////////
+//////////////////////////////////enroll/////////////////////////////////
+
+interface EnrollLectureInNewCourseWithoutSchedulingParams {
+  lecture_code: string;
+}
+
+interface EnrollLectureInNewCourseWithSchedulingParams
+  extends EnrollLectureInNewCourseWithoutSchedulingParams {
+  daily_target_time: number;
+  scheduling: number[];
+  expected_end_date: string;
+}
+
+interface EnrollLectureInNewCourseParams {
+  query: {
+    use_schedule: boolean;
+  };
+  body:
+    | EnrollLectureInNewCourseWithoutSchedulingParams
+    | EnrollLectureInNewCourseWithSchedulingParams;
+}
+
+interface EnrollLectureInExistingCourseParams
+extends EnrollLectureInNewCourseWithoutSchedulingParams {}
+
+interface EnrollLectureResponse extends Response {
+  course_id: number;
+  lecture_id: number;
+  title: string;
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -10,8 +10,13 @@ interface WeekRange {
 
 //////////////////////////////////toast//////////////////////////////////
 
+interface Emoji  {
+  lecture_enrollment: string;
+  error: string;
+} 
+
 interface CustomToast {
-  type: 'success' | 'error';
+  type: keyof Emoji;
   title: string;
   description: string;
   buttonLabel?: string;
@@ -230,7 +235,7 @@ interface EnrollLectureInNewCourseParams {
   query: {
     use_schedule: boolean;
   };
-  body:
+  body?:
     | EnrollLectureInNewCourseWithoutSchedulingParams
     | EnrollLectureInNewCourseWithSchedulingParams;
 }


### PR DESCRIPTION
## Motivation 🤔
- 강의 등록 API를 연결하고, 강의 등록 로딩 state 및 완료 알림 필요

<br>

## Key changes ✅
### 강의 일정 관리
- `예상 수강 종료일`이 주 단위에서, 일 단위로 계산하도록 수정되었습니다.

### toast 레이아웃 수정
- 강의 등록
<img width="807" alt="Untitled" src="https://github.com/4m9d/sroom-fe/assets/63336701/9913f87e-79b1-4311-a75f-bc9fc41c5314">
- 오류
<img width="810" alt="Untitled" src="https://github.com/4m9d/sroom-fe/assets/63336701/8e7c9822-33ca-459a-9b25-deea690dbebf">

### 강의 등록
- 강의 등록 API를 연결하였습니다.
- 강의 등록 중에는 버튼에 텍스트 대신 loading spinner를 표시
- 등록이 완료되면, 모달이 꺼지면서 등록 완료 toast 알림이 나타남
_(추후 `수강하러 가기` 버튼을 통해 수강 페이지로 navigate 연결 예정)_
![ezgif com-video-to-gif (2)](https://github.com/4m9d/sroom-fe/assets/63336701/613f4d9d-0031-46ab-a00e-52102ec744fa)

<br>

## To reviewers 🙏
- 토스트 디자인을 수정하였는데 괜찮은가요?