### PR TITLE
Feat/#55/course video route(swm 272)

### DIFF
--- a/src/app/course/[course_id]/page.tsx
+++ b/src/app/course/[course_id]/page.tsx
@@ -2,13 +2,21 @@ import { fetchCourseDetail } from '@/src/api/courses/courses';
 import CourseTaking from '@/src/components/course/CourseTaking';
 
 export default async function CourseTakingPage({
-  params: { course_id }
+  params,
+  searchParams
 }: CourseTakingPageParams) {
-  const courseDetail = await fetchCourseDetail(parseInt(course_id));
+  const courseDetail = await fetchCourseDetail(parseInt(params.course_id));
 
   return (
     <div className='min-h-[calc(100vh-4rem)] max-h-[calc(100vh-4rem)] bg-zinc-50 flex items-stretch'>
-      <CourseTaking courseDetail={courseDetail} />
+      <CourseTaking
+        courseDetail={courseDetail}
+        currentCourseVideoId={
+          searchParams.course_video_id
+            ? parseInt(searchParams.course_video_id)
+            : courseDetail.last_view_video.course_video_id
+        }
+      />
     </div>
   );
 }

--- a/src/components/course/CourseTaking.tsx
+++ b/src/components/course/CourseTaking.tsx
@@ -5,25 +5,49 @@ import YoutubePlayer from './YoutubePlayer';
 import CourseDetailDrawer from './drawer/courseDetail/CourseDetailDrawer';
 import CourseMaterialDrawer from './drawer/courseMaterial/CourseMaterialDrawer';
 import PrevNextController from './PrevNextController';
+import { useRouter } from 'next/navigation';
 
 type Props = {
   courseDetail: CourseDetail;
+  currentCourseVideoId: number;
 };
 
-export default function CourseTaking({ courseDetail }: Props) {
-  const { last_view_video } = courseDetail;
-
-  const [currentPlayingVideo, setCurrentPlayingVideo] =
-    useState<LastViewVideo>(last_view_video);
+export default function CourseTaking({
+  courseDetail,
+  currentCourseVideoId
+}: Props) {
+  const last_view_video = findVideoById() as LastViewVideo;
+  const router = useRouter();
+  const currentPlayingVideo = last_view_video;
+  
   const [prevPlayingVideo, setPrevPlayingVideo] =
     useState<LastViewVideo | null>(last_view_video);
   const [nextPlayingVideo, setNextPlayingVideo] =
     useState<LastViewVideo | null>(last_view_video);
 
+  function findVideoById() {
+    const videos = courseDetail.sections.flatMap((section) => section.videos);
+    const video = videos.find(
+      (video) => video.course_video_id === currentCourseVideoId
+    );
+    if (video === undefined) {
+      return null;
+    }
+    const last_view_video: LastViewVideo = {
+      video_code: video.video_code,
+      course_video_id: video.course_video_id,
+      video_id: video.video_id,
+      last_view_duration: video.last_view_duration,
+      channel: video.channel,
+      video_title: video.video_title
+    };
+    return last_view_video;
+  }
+
   const searchPrevVideo = useCallback(() => {
     const videos = courseDetail.sections.flatMap((section) => section.videos);
     const currentPlayingVideoIdx = videos.findIndex((video) => {
-      return video.video_id === currentPlayingVideo.video_id;
+      return video.course_video_id === currentCourseVideoId;
     });
 
     if (currentPlayingVideoIdx === 0) {
@@ -33,6 +57,7 @@ export default function CourseTaking({ courseDetail }: Props) {
       const prevVideo = videos[currentPlayingVideoIdx - 1];
       const video: LastViewVideo = {
         video_code: prevVideo.video_code,
+        course_video_id: prevVideo.course_video_id,
         video_id: prevVideo.video_id,
         last_view_duration: prevVideo.last_view_duration,
         channel: prevVideo.channel,
@@ -41,12 +66,12 @@ export default function CourseTaking({ courseDetail }: Props) {
 
       setPrevPlayingVideo(() => video);
     }
-  }, [courseDetail.sections, currentPlayingVideo.video_id]);
+  }, [courseDetail.sections, currentCourseVideoId]);
 
   const searchNextVideo = useCallback(() => {
     const videos = courseDetail.sections.flatMap((section) => section.videos);
     const currentPlayingVideoIdx = videos.findIndex((video) => {
-      return video.video_id === currentPlayingVideo.video_id;
+      return video.course_video_id === currentCourseVideoId;
     });
 
     if (currentPlayingVideoIdx === videos.length - 1) {
@@ -56,6 +81,7 @@ export default function CourseTaking({ courseDetail }: Props) {
       const nextVideo = videos[currentPlayingVideoIdx + 1];
       const video: LastViewVideo = {
         video_code: nextVideo.video_code,
+        course_video_id: nextVideo.course_video_id,
         video_id: nextVideo.video_id,
         last_view_duration: nextVideo.last_view_duration,
         channel: nextVideo.channel,
@@ -64,25 +90,26 @@ export default function CourseTaking({ courseDetail }: Props) {
 
       setNextPlayingVideo(() => video);
     }
-  }, [courseDetail.sections, currentPlayingVideo.video_id]);
+  }, [courseDetail.sections, currentCourseVideoId]);
 
   const onVideoEnd = useCallback(() => {
     searchNextVideo();
     if (nextPlayingVideo === null) return;
-    setCurrentPlayingVideo(() => nextPlayingVideo);
-  }, [searchNextVideo, nextPlayingVideo]);
+    router.push(
+      `/course/${courseDetail.course_id}?course_video_id=${nextPlayingVideo.course_video_id}`
+    );
+  }, [searchNextVideo, nextPlayingVideo, router, courseDetail.course_id]);
 
   useEffect(() => {
     searchPrevVideo();
     searchNextVideo();
-  }, [currentPlayingVideo, searchPrevVideo, searchNextVideo]);
+  }, [searchPrevVideo, searchNextVideo]);
 
   return (
     <div className='flex items-stretch flex-1 h-full bg-sroom-gray-200'>
       <CourseDetailDrawer
         courseDetail={courseDetail}
         currentPlayingVideo={currentPlayingVideo}
-        setCurrentPlayingVideo={setCurrentPlayingVideo}
       />
       <div id='background' className='flex-1 overflow-scroll'>
         <CourseHeader
@@ -98,9 +125,9 @@ export default function CourseTaking({ courseDetail }: Props) {
         />
         <div id='controller'>
           <PrevNextController
+            course_id={courseDetail.course_id}
             prevPlayingVideo={prevPlayingVideo}
             nextPlayingVideo={nextPlayingVideo}
-            setCurrentPlayingVideo={setCurrentPlayingVideo}
           />
         </div>
       </div>

--- a/src/components/course/PrevNextController.tsx
+++ b/src/components/course/PrevNextController.tsx
@@ -1,26 +1,53 @@
-import { Dispatch } from 'react';
+'use client';
+import { useRouter } from 'next/navigation';
 import Button from '../ui/button/Button';
 import ArrowRightSVG from '@/public/icon/ArrowRight';
+import { useCallback, useEffect } from 'react';
 
 type Props = {
+  course_id: number;
   prevPlayingVideo: LastViewVideo | null;
   nextPlayingVideo: LastViewVideo | null;
-  setCurrentPlayingVideo: Dispatch<React.SetStateAction<LastViewVideo>>;
 };
 
 export default function PrevNextController({
+  course_id,
   prevPlayingVideo,
-  nextPlayingVideo,
-  setCurrentPlayingVideo
+  nextPlayingVideo
 }: Props) {
+  const router = useRouter();
+  
+  const prevVideoRoute = `/course/${course_id}?course_video_id=${prevPlayingVideo?.course_video_id}`;
+  const nextVideoRoute = `/course/${course_id}?course_video_id=${nextPlayingVideo?.course_video_id}`;
+
   const controllerClickHandler = (type: 'prev' | 'next') => {
     if (type === 'prev' && prevPlayingVideo !== null) {
-      setCurrentPlayingVideo(() => prevPlayingVideo);
+      router.push(prevVideoRoute);
     }
     if (type === 'next' && nextPlayingVideo !== null) {
-      setCurrentPlayingVideo(() => nextPlayingVideo);
+      router.push(nextVideoRoute);
     }
   };
+
+  const prefetchPrevAndNextVideo = useCallback(() => {
+    if (prevPlayingVideo !== null) {
+      router.prefetch(prevVideoRoute);
+    }
+    if (nextPlayingVideo !== null) {
+      router.prefetch(nextVideoRoute);
+    }
+  }, [
+    prevVideoRoute,
+    nextVideoRoute,
+    prevPlayingVideo,
+    nextPlayingVideo,
+    router
+  ]);
+
+  useEffect(() => {
+    prefetchPrevAndNextVideo();
+  }, [prefetchPrevAndNextVideo]);
+
   return (
     <div className='flex flex-wrap justify-center max-w-screen-lg gap-1 mx-auto my-2 md:gap-3 lg:my-5 lg:px-28 shrink-0'>
       <Button

--- a/src/components/course/drawer/courseDetail/CourseDetailDrawer.tsx
+++ b/src/components/course/drawer/courseDetail/CourseDetailDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { AnimatePresence, motion, useAnimationControls } from 'framer-motion';
-import { Dispatch, SetStateAction, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import SectionList from './SectionList';
 import CourseDetailHeader from './CourseDetailHeader';
 import DrawerMenuButtons from './DrawerMenuButtons';
@@ -9,28 +9,23 @@ import ArrowRightSVG from '@/public/icon/ArrowRight';
 type Props = {
   courseDetail: CourseDetail;
   currentPlayingVideo: LastViewVideo;
-  setCurrentPlayingVideo: Dispatch<SetStateAction<LastViewVideo>>;
 };
 
 export default function CourseDetailDrawer({
   courseDetail,
-  currentPlayingVideo,
-  setCurrentPlayingVideo
+  currentPlayingVideo
 }: Props) {
   const controls = useAnimationControls();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const {
-    course_id,
     thumbnail,
     course_title,
     channels,
     course_duration,
     total_video_count,
-    completed_video_count,
     progress,
     current_duration,
-    last_view_video,
     sections,
     use_schedule
   } = courseDetail;
@@ -70,7 +65,7 @@ export default function CourseDetailDrawer({
               transition={{ ease: 'easeInOut', duration: 0.25 }}
               className='absolute top-0 left-0 flex flex-col justify-between h-full'
             >
-              <div>
+              <div className='overflow-y-scroll'>
                 <CourseDetailHeader
                   course_title={course_title}
                   channels={channels}
@@ -81,13 +76,14 @@ export default function CourseDetailDrawer({
                   progress={progress}
                 />
                 <SectionList
+                  course_id={courseDetail.course_id}
                   sections={sections}
                   use_schedule={use_schedule}
                   course_title={course_title}
                   currentPlayingVideo={currentPlayingVideo}
-                  setCurrentPlayingVideo={setCurrentPlayingVideo}
                 />
               </div>
+              <div className='h-[2px] bg-sroom-gray-200' />
               <DrawerMenuButtons />
             </motion.div>
           )}

--- a/src/components/course/drawer/courseDetail/CourseDetailDrawer.tsx
+++ b/src/components/course/drawer/courseDetail/CourseDetailDrawer.tsx
@@ -65,7 +65,7 @@ export default function CourseDetailDrawer({
               transition={{ ease: 'easeInOut', duration: 0.25 }}
               className='absolute top-0 left-0 flex flex-col justify-between h-full'
             >
-              <div className='overflow-y-scroll'>
+              <div className='flex-1 overflow-y-scroll'>
                 <CourseDetailHeader
                   course_title={course_title}
                   channels={channels}

--- a/src/components/course/drawer/courseDetail/DrawerMenuButtons.tsx
+++ b/src/components/course/drawer/courseDetail/DrawerMenuButtons.tsx
@@ -4,7 +4,7 @@ type Props = {};
 
 export default function DrawerMenuButtons({}: Props) {
   return (
-    <div className='flex justify-between h-12 gap-2 px-2 mb-5 shrink-0'>
+    <div className='flex justify-between h-12 gap-2 px-2 my-5'>
       <Button className='w-1/2 bg-sroom-brand text-sroom-white'>
         강의 자료
       </Button>

--- a/src/components/course/drawer/courseDetail/SectionList.tsx
+++ b/src/components/course/drawer/courseDetail/SectionList.tsx
@@ -1,36 +1,35 @@
-import { Dispatch, SetStateAction } from 'react';
 import SectionAccordion from './SectionAccordion';
 
 type Props = {
   sections: Section[];
   use_schedule: boolean;
+  course_id: number;
   course_title: string;
   currentPlayingVideo: LastViewVideo;
-  setCurrentPlayingVideo: Dispatch<SetStateAction<LastViewVideo>>;
 };
 
 export default function SectionList({
   sections,
   use_schedule,
+  course_id,
   course_title,
-  currentPlayingVideo,
-  setCurrentPlayingVideo
+  currentPlayingVideo
 }: Props) {
   return (
     <section>
       <h2 className='px-5 py-2 font-semibold border-b-2 border-sroom-gray-200'>
         강의 목차
       </h2>
-      <ul className='overflow-y-scroll max-h-[calc(100vh-33rem)] sm:max-h-[calc(100vh-35rem)] md:max-h-[calc(100vh-37rem)] border-b-2 border-sroom-gray-200'>
+      <ul className='pb-10'>
         {sections.map((section) => {
           return (
             <SectionAccordion
               key={section.section}
               section={section}
               use_schedule={use_schedule}
+              course_id={course_id}
               course_title={course_title}
               currentPlayingVideo={currentPlayingVideo}
-              setCurrentPlayingVideo={setCurrentPlayingVideo}
             />
           );
         })}

--- a/src/components/gnb/NavBar.tsx
+++ b/src/components/gnb/NavBar.tsx
@@ -21,7 +21,7 @@ export default function NavBar({ logo, profileDropdown }: Props) {
   const hidden = name ? '' : 'hidden';
 
   return (
-    <nav className='max-h-[4rem] navbar shadow-sm'>
+    <nav className='max-h-[4rem] navbar shadow-sm z-50'>
       <div className='flex justify-between gap-4 lg:gap-8 px-4 lg:px-24 mx-auto max-h-[4rem] navbar max-w-screen-2xl'>
         <h1 className='w-6 sm:w-20 lg:w-36 shrink-0'>
           <Link href='/' className='shrink-0 mr-14'>

--- a/src/components/main/scheduling/SchedulingIntro.tsx
+++ b/src/components/main/scheduling/SchedulingIntro.tsx
@@ -17,7 +17,7 @@ export default function SchedulingIntro({}) {
             />
           </div>
         </div>
-        <div className='absolute bottom-0 right-0 w-[79%]'>
+        <div className='absolute bottom-0 -right-[0.3px] w-[79%]'>
           <div className='pb-[56.5%] relative object-cover'>
             <Image
               src={'/image/main/calendar.webp'}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -267,11 +267,15 @@ interface CourseTakingPageParams {
   params: {
     course_id: string;
   };
+  searchParams: {
+    course_video_id: string;
+  };
 }
 
 interface Video {
   video_index: number;
   video_id: number;
+  course_video_id: number;
   channel: string;
   video_title: string;
   video_code: string;
@@ -282,6 +286,7 @@ interface Video {
 
 type LastViewVideo = {
   [key in
+    | 'course_video_id'
     | 'video_id'
     | 'video_title'
     | 'video_code'


### PR DESCRIPTION
## Motivation 🤔
- 코스 내에서 영상 선택에 대한 브라우저 방문 기록을 남겨, 뒤로 가기 및 앞으로 가기 기능을 활용할 수 있도록 하기 위함

<br>

## Key changes ✅
### 강의 수강 페이지
- 코스 내 영상들에 대한 각각의 라우트가 할당됩니다 (`/course/{courseId}?course_video_id={course_video_id}`)
  - 강의 수강 페이지 내에서 뒤로 가기, 앞으로 가기, 새로고침 등에 반응합니다
### 강의 상세 사이드바
- `강의 목차` 부분만 스크롤 형식으로 적용하였던 것에서, 이제는 하단 메뉴 버튼을 제외한 모든 부분을 스크롤 영역으로 적용하였습니다

<br>

## To reviewers 🙏
- 예상치 못한 버그가 있는지 확인해주세요
- 강의 목차 부분이 시인성도 떨어지고 조금 답답해보여서 전체를 스크롤 영역으로 지정하였는데, 괜찮은지 봐주세요