### PR TITLE
Feat/#65/block small devices(swm 315)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import AuthSessionProvider from '../providers/AuthSessionProvider';
 import './globals.css';
 import { Inter } from 'next/font/google';
 import { Toaster } from 'react-hot-toast';
+import ResolutionCheck from '../components/ui/ResolutionCheck';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -21,20 +22,22 @@ export default function RootLayout({ children, modal }: Props) {
   return (
     <html lang='ko'>
       <body className={inter.className}>
-          <AuthSessionProvider>
-            <QueryProvider>
-              <NavBar
-                logo='스룸'
-                profileDropdown={[
-                  { id: 1, menuTitle: '내 강의실', menuRoute: '/classroom' },
-                  { id: 2, menuTitle: '강의 자료', menuRoute: '/' }
-                ]}
-              />
+        <AuthSessionProvider>
+          <QueryProvider>
+            <NavBar
+              logo='스룸'
+              profileDropdown={[
+                { id: 1, menuTitle: '내 강의실', menuRoute: '/classroom' },
+                { id: 2, menuTitle: '강의 자료', menuRoute: '/' }
+              ]}
+            />
+            <ResolutionCheck>
               {children}
               {modal}
-            <Toaster containerStyle={{zIndex: 9999}}/>
-            </QueryProvider>
-          </AuthSessionProvider>
+            </ResolutionCheck>
+            <Toaster containerStyle={{ zIndex: 9999 }} />
+          </QueryProvider>
+        </AuthSessionProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,10 +32,10 @@ export default function RootLayout({ children, modal }: Props) {
               ]}
             />
             <ResolutionCheck>
+              <Toaster containerStyle={{ zIndex: 9999 }} />
               {children}
               {modal}
             </ResolutionCheck>
-            <Toaster containerStyle={{ zIndex: 9999 }} />
           </QueryProvider>
         </AuthSessionProvider>
       </body>

--- a/src/components/classroom/ClassroomCourseCard.tsx
+++ b/src/components/classroom/ClassroomCourseCard.tsx
@@ -23,6 +23,7 @@ export default function ClassroomCourseCard({ course }: Props) {
       onClick={() => router.push(`/course/${course.course_id}`)}
     >
       <Button
+        onClick={() => setUndevelopedAlertToast('course-deletion')}
         hoverEffect={true}
         className='absolute top-0 right-0 text-xs font-normal md:text-sm text-sroom-black-100 !h-8'
       >
@@ -63,7 +64,7 @@ export default function ClassroomCourseCard({ course }: Props) {
         </div>
         <div className='flex items-center gap-2'>
           <Button
-            onClick={setUndevelopedAlertToast}
+            onClick={() => setUndevelopedAlertToast('scrap')}
             hoverEffect={true}
             className='!h-8 text-xs xl:text-sm'
           >
@@ -73,7 +74,7 @@ export default function ClassroomCourseCard({ course }: Props) {
             </span>
           </Button>
           <Button
-            onClick={setUndevelopedAlertToast}
+            onClick={() => setUndevelopedAlertToast('review')}
             hoverEffect={true}
             className='!h-8 text-xs xl:text-sm'
           >

--- a/src/components/classroom/ClassroomCourseCard.tsx
+++ b/src/components/classroom/ClassroomCourseCard.tsx
@@ -7,6 +7,7 @@ import ProgressBar from '../ui/progress/ProgressBar';
 import Button from '../ui/button/Button';
 import { useRouter } from 'next/navigation';
 import ArrowRightSVG from '@/public/icon/ArrowRight';
+import setUndevelopedAlertToast from '@/src/util/toast/setUndevelopedAlertToast';
 
 type Props = {
   course: Course;
@@ -61,13 +62,21 @@ export default function ClassroomCourseCard({ course }: Props) {
           </div>
         </div>
         <div className='flex items-center gap-2'>
-          <Button hoverEffect={true} className='!h-8 text-xs xl:text-sm'>
-            <p>강의 자료 보기</p>
+          <Button
+            onClick={setUndevelopedAlertToast}
+            hoverEffect={true}
+            className='!h-8 text-xs xl:text-sm'
+          >
+            <p>오답 노트 보기</p>
             <span className='w-3 ml-1 stroke-sroom-black-400'>
               <ArrowRightSVG />
             </span>
           </Button>
-          <Button hoverEffect={true} className='!h-8 text-xs xl:text-sm'>
+          <Button
+            onClick={setUndevelopedAlertToast}
+            hoverEffect={true}
+            className='!h-8 text-xs xl:text-sm'
+          >
             <p>후기 / 평점</p>
             <span className='w-3 ml-1 stroke-sroom-black-400'>
               <ArrowRightSVG />

--- a/src/components/classroom/ClassroomHeader.tsx
+++ b/src/components/classroom/ClassroomHeader.tsx
@@ -1,3 +1,4 @@
+import setUndevelopedAlertToast from '@/src/util/toast/setUndevelopedAlertToast';
 import Button from '../ui/button/Button';
 
 type Props = {
@@ -11,7 +12,10 @@ export default function ClassroomHeader({
 }: Props) {
   return (
     <div className='flex items-center justify-between mb-7'>
-      <Button className='text-xs md:px-6 md:text-sm bg-sroom-brand text-sroom-white'>
+      <Button
+        onClick={setUndevelopedAlertToast}
+        className='text-xs md:px-6 md:text-sm bg-sroom-brand text-sroom-white'
+      >
         후기 / 평점 작성하기
       </Button>
       <div className='flex gap-1 font-bold'>
@@ -21,7 +25,8 @@ export default function ClassroomHeader({
         </p>
         <p className='text-base md:text-lg'>
           미수강 강의
-          <span className='pl-1 text-xl md:text-3xl'>{unfinished_course}</span>개
+          <span className='pl-1 text-xl md:text-3xl'>{unfinished_course}</span>
+          개
         </p>
       </div>
     </div>

--- a/src/components/classroom/ClassroomHeader.tsx
+++ b/src/components/classroom/ClassroomHeader.tsx
@@ -13,7 +13,7 @@ export default function ClassroomHeader({
   return (
     <div className='flex items-center justify-between mb-7'>
       <Button
-        onClick={setUndevelopedAlertToast}
+        onClick={() => setUndevelopedAlertToast('review')}
         className='text-xs md:px-6 md:text-sm bg-sroom-brand text-sroom-white'
       >
         후기 / 평점 작성하기

--- a/src/components/course/drawer/courseDetail/DrawerMenuButtons.tsx
+++ b/src/components/course/drawer/courseDetail/DrawerMenuButtons.tsx
@@ -7,10 +7,10 @@ export default function DrawerMenuButtons({}: Props) {
 
   return (
     <div className='flex justify-between h-12 gap-2 px-2 my-5'>
-      <Button onClick={setUndevelopedAlertToast} className='w-1/2 bg-sroom-brand text-sroom-white'>
+      <Button onClick={() => setUndevelopedAlertToast('scrap')} className='w-1/2 bg-sroom-brand text-sroom-white'>
         오답 노트
       </Button>
-      <Button onClick={setUndevelopedAlertToast} className='w-1/2 bg-sroom-black-400 text-sroom-white'>
+      <Button onClick={() => setUndevelopedAlertToast('course-modification')} className='w-1/2 bg-sroom-black-400 text-sroom-white'>
         강의 편집
       </Button>
     </div>

--- a/src/components/course/drawer/courseDetail/DrawerMenuButtons.tsx
+++ b/src/components/course/drawer/courseDetail/DrawerMenuButtons.tsx
@@ -1,14 +1,16 @@
 import Button from '@/src/components/ui/button/Button';
+import setUndevelopedAlertToast from '@/src/util/toast/setUndevelopedAlertToast';
 
 type Props = {};
 
 export default function DrawerMenuButtons({}: Props) {
+
   return (
     <div className='flex justify-between h-12 gap-2 px-2 my-5'>
-      <Button className='w-1/2 bg-sroom-brand text-sroom-white'>
-        강의 자료
+      <Button onClick={setUndevelopedAlertToast} className='w-1/2 bg-sroom-brand text-sroom-white'>
+        오답 노트
       </Button>
-      <Button className='w-1/2 bg-sroom-black-400 text-sroom-white'>
+      <Button onClick={setUndevelopedAlertToast} className='w-1/2 bg-sroom-black-400 text-sroom-white'>
         강의 편집
       </Button>
     </div>

--- a/src/components/course/drawer/courseMaterial/CourseMaterialContent.tsx
+++ b/src/components/course/drawer/courseMaterial/CourseMaterialContent.tsx
@@ -66,10 +66,10 @@ export default function CourseMaterialContent({
                 </div>
                 <div className='flex flex-col items-center justify-center'>
                   <p className='mb-1 text-lg font-semibold text-sroom-black-300'>
-                    강의 자료를 생성중이에요!
+                    강의 자료를 생성 중이에요!
                   </p>
                   <p className='font-normal text-sroom-black-100'>
-                    조금만 기다려주세요
+                    조금만 기다려 주세요
                   </p>
                 </div>
               </div>
@@ -100,7 +100,7 @@ export default function CourseMaterialContent({
                     정책상 강의 자료를 생성할 수 없어요!
                   </p>
                   <p className='font-normal text-sroom-black-100'>
-                    다른 강의에서 스룸의 AI 자동 생성 자료를 확인해보세요
+                    다른 강의에서 스룸의 AI 자동 생성 자료를 확인해 보세요
                   </p>
                 </div>
               </div>

--- a/src/components/course/drawer/courseMaterial/quizzes/CourseMaterialQuizzes.tsx
+++ b/src/components/course/drawer/courseMaterial/quizzes/CourseMaterialQuizzes.tsx
@@ -54,7 +54,7 @@ export default function CourseMaterialQuizzes({
 
       return {
         ...selectedAnswer,
-        is_correct: isCorrect,
+        is_correct: quiz?.type === QuizType.SHORT_ANSWER ? true : isCorrect,
         is_submitted: true
       };
     });

--- a/src/components/course/drawer/courseMaterial/quizzes/CourseMaterialQuizzes.tsx
+++ b/src/components/course/drawer/courseMaterial/quizzes/CourseMaterialQuizzes.tsx
@@ -69,17 +69,13 @@ export default function CourseMaterialQuizzes({
   }
 
   async function updateCourseQuizGradeMutation() {
-    const gradeResult = selectedAnswerList
-      .filter((selectedAnswer) => {
-        return selectedAnswer.type !== QuizType.SHORT_ANSWER;
-      })
-      .map((selectedAnswer) => {
-        return {
-          id: selectedAnswer.id,
-          submitted_answer: selectedAnswer.submitted_answer,
-          is_correct: selectedAnswer.is_correct
-        };
-      }) as updateQuizGradeParams[];
+    const gradeResult = selectedAnswerList.map((selectedAnswer) => {
+      return {
+        id: selectedAnswer.id,
+        submitted_answer: selectedAnswer.submitted_answer,
+        is_correct: selectedAnswer.is_correct
+      };
+    }) as updateQuizGradeParams[];
     const result = await updateCourseQuizGrade(courseVideoId, gradeResult);
     return result;
   }

--- a/src/components/lectureDetail/LectureDetailCard.tsx
+++ b/src/components/lectureDetail/LectureDetailCard.tsx
@@ -81,7 +81,7 @@ export default function LectureDetailCard({
               </div>
             </div>
             <LectureEnrollmentButton
-              disabled={isIndexListFetched}
+              disabled={isIndexListFetched === false}
               onEnrollSuccess={onClose}
               is_playlist={is_playlist}
               courses={courses}

--- a/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
+++ b/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
@@ -193,7 +193,9 @@ export default function LectureEnrollmentButton({
         <Button
           disabled={disabled}
           onClick={() => {}}
-          className='w-full !h-[3rem] font-bold peer text-sroom-white bg-sroom-black-400 md:text-base'
+          className={`w-full !h-[3rem] font-bold peer text-sroom-white bg-sroom-black-400 md:text-base ${
+            disabled ? 'opacity-80' : ''
+          }`}
         >
           {isLoading ? (
             <LoadingSpinner className='text-sroom-brand loading-sm' />

--- a/src/components/main/ui/TextLoopIntro.tsx
+++ b/src/components/main/ui/TextLoopIntro.tsx
@@ -34,7 +34,7 @@ const TextLoop = ({
         repeatDelay: repeatDelay,
         delay: type === 'back-up' ? delay : 0
       }}
-      className={`${className} pl-[100%] absolute flex h-full min-w-full gap-3 whitespace-nowrap text-[5px] sm:text-sm md:text-lg lg:text-xl xl:text-2xl opacity-90`}
+      className={`${className} pl-[100%] absolute flex h-full min-w-full gap-3 whitespace-nowrap text-[3px] leading-3 sm:text-sm md:text-lg lg:text-xl xl:text-2xl opacity-90`}
     >
       {children}
     </motion.div>

--- a/src/components/scheduling/SchedulingSlider.tsx
+++ b/src/components/scheduling/SchedulingSlider.tsx
@@ -27,28 +27,29 @@ export default function SchedulingSlider({
         min={min}
         max={max}
         value={value}
-        className={`${className} appearance-none bg-transparent w-full [&::-webkit-slider-runnable-track]:h-[4px] [&::-webkit-slider-runnable-track]:bg-sroom-gray-500 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-[10px] [&::-webkit-slider-thumb]:w-[10px] [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:-mt-[3px] [&::-webkit-slider-thumb]:bg-transparent`}
+        className={`${className} mt-4 appearance-none bg-transparent w-full [&::-webkit-slider-runnable-track]:h-[4px] [&::-webkit-slider-runnable-track]:bg-sroom-gray-500 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-[13px] [&::-webkit-slider-thumb]:w-[13px] [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:-mt-[4px] [&::-webkit-slider-thumb]:bg-transparent [&::-webkit-slider-thumb]:z-10`}
         step={step}
       />
-      <div className='absolute top-[10px] left-0 flex justify-between w-full pointer-events-none'>
+      <div className='absolute top-[10px] left-0 flex justify-between w-full pointer-events-none hover:cursor-pointer'>
         <div
           aria-hidden
           style={{
             width: `${((value - min) / (max - min)) * 100}%`,
             position: 'absolute',
-            top: '4px',
+            top: '5.5px',
             height: '4px',
             left: '0',
-            zIndex: '10',
             backgroundColor: 'var(--primary-color)'
           }}
         />
         {new Array(level + 1).fill(0).map((_, index) => (
-          <div
+          <button
+            type='button'
             aria-hidden
             data-tip={getFormattedTime(value)}
+            onClick={() => setValue(min + step * index)}
             key={index}
-            className={`w-[12px] h-[12px] border-2 z-20
+            className={`w-[15px] h-[15px] border-2 z-20 px-1 hover:cursor-pointer
              ${
                min + step * index > value
                  ? 'bg-sroom-gray-500 border-sroom-gray-500'

--- a/src/components/ui/ResolutionCheck.tsx
+++ b/src/components/ui/ResolutionCheck.tsx
@@ -1,0 +1,38 @@
+'use client';
+import useWindowSize from '@/src/hooks/useWindowSize';
+import { usePathname } from 'next/navigation';
+
+type Props = { children: React.ReactNode };
+const BROWSER_MIN_WIDTH = 500;
+
+export default function ResolutionCheck({ children }: Props) {
+  const { width } = useWindowSize();
+  const pathname = usePathname();
+
+  const isInnerRoute = pathname !== '/';
+  const isSmallerThanBrowser = width && width < BROWSER_MIN_WIDTH;
+
+  if (isSmallerThanBrowser && isInnerRoute) {
+    return (
+      <div className='px-4 mt-20 text-sroom-black-400 break-keep'>
+        <h2 className='w-full text-xl font-bold'>
+          <div className='flex'>
+            <span className='mr-1'>{'스룸은'}</span>
+            <span className='text-sroom-brand'>{'태블릿'}</span>
+            <div className='px-1 animate-bounce'>📝</div>
+            <span className='mr-1'>{'과'}</span>
+            <span className='text-sroom-brand'>{'PC'}</span>
+            <div className='px-1 animate-[bounce_1s_infinite_0.5s]'>💻</div>
+            {'에'}
+          </div>
+          <p>{'최적화 되어있어요 :)'}</p>
+        </h2>
+        <h3 className='mt-3 text-sm font-medium text-sroom-black-100'>
+          {'더 쾌적한 환경에서 스룸을 만나보세요!'}
+        </h3>
+      </div>
+    );
+  } else {
+    return <>{children}</>;
+  }
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -5,7 +5,8 @@ import LectureSVG from '@/public/icon/Lecture';
 
 const Emoji: Emoji = {
   lecture_enrollment: '🤓',
-  error: '🚫'
+  error: '🚫',
+  undeveloped: '🚧'
 };
 
 const TOAST_DELAY = 4;
@@ -25,12 +26,8 @@ export default function Toast({ toast }: { toast: CustomToast }) {
           repeatDelay: TOAST_DELAY - 0.25
         }}
         role='alert'
-        className={`fixed h-[5.5rem] z-50 flex w-[88%] lg:w-[60%] px-7 py-6 justify-between bottom-10 lg:bottom-14 left-[calc(6%)] lg:left-[20%] items-center gap-5 shadow-xl text-sroom-black-400 ${
-          type === 'error'
-            ? 'bg-red-400'
-            : type === 'lecture_enrollment'
-            ? 'bg-sroom-white'
-            : ''
+        className={`fixed h-[5.5rem] z-[99999] flex w-[88%] lg:w-[60%] px-7 py-6 justify-between bottom-10 lg:bottom-14 left-[calc(6%)] lg:left-[20%] items-center gap-5 shadow-xl text-sroom-black-400 ${
+          type === 'error' ? 'bg-red-400' : 'bg-sroom-white'
         }`}
       >
         <div className='flex items-center gap-7 shrink-0'>

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -19,7 +19,7 @@ export default function Toast({ toast }: { toast: CustomToast }) {
       <motion.div
         initial={{ y: 200 }}
         animate={{ y: 0 }}
-        exit={{ y: 200 }}
+        exit={{ y: 200, visibility: 'hidden' }}
         transition={{
           repeat: 1,
           repeatType: 'reverse',

--- a/src/components/ui/button/Button.tsx
+++ b/src/components/ui/button/Button.tsx
@@ -2,7 +2,7 @@ type Props = {
   className?: string;
   id?: string;
   children?: React.ReactNode;
-  onClick?: () => void;
+  onClick: () => void;
   disabled?: boolean;
   hoverEffect?: boolean;
 };
@@ -19,7 +19,7 @@ export default function Button({
     <button
       id={id}
       disabled={disabled}
-      onClick={onClick}
+      onClick={() => onClick()}
       className={`${className} ${disabled ? '' : 'hover:opacity-90'} ${
         hoverEffect ? 'hover:bg-sroom-gray-300' : ''
       } text-sm font-bold h-12 py-1 px-2 md:px-4 flex active:focus:scale-95 transition-all items-center justify-center rounded-none break-keep`}

--- a/src/components/ui/button/Button.tsx
+++ b/src/components/ui/button/Button.tsx
@@ -2,7 +2,7 @@ type Props = {
   className?: string;
   id?: string;
   children?: React.ReactNode;
-  onClick: () => void;
+  onClick?: () => void;
   disabled?: boolean;
   hoverEffect?: boolean;
 };
@@ -19,7 +19,7 @@ export default function Button({
     <button
       id={id}
       disabled={disabled}
-      onClick={() => onClick()}
+      onClick={onClick}
       className={`${className} ${disabled ? '' : 'hover:opacity-90'} ${
         hoverEffect ? 'hover:bg-sroom-gray-300' : ''
       } text-sm font-bold h-12 py-1 px-2 md:px-4 flex active:focus:scale-95 transition-all items-center justify-center rounded-none break-keep`}

--- a/src/components/ui/quizCard/QuizCard.tsx
+++ b/src/components/ui/quizCard/QuizCard.tsx
@@ -41,7 +41,7 @@ export default function QuizCard({
   const shortAnswerHandler = (inputtedAnswer: string) => {
     const updatedAnswer = {
       ...selectedAnswer,
-      submitted_answer: inputtedAnswer.trim()
+      submitted_answer: inputtedAnswer.trim().slice(0, 256)
     };
     updateSelectedAnswerList(updatedAnswer);
   };

--- a/src/components/ui/quizCard/quizType/ShortAnswer.tsx
+++ b/src/components/ui/quizCard/quizType/ShortAnswer.tsx
@@ -11,9 +11,10 @@ export default function ShortAnswer({
   return (
     <>
       <textarea
-        className='w-full !h-40 p-3 border rounded-none resize-none textarea border-sroom-gray-500'
+        className='w-full !h-40 p-3 leading-6 border rounded-none resize-none textarea border-sroom-gray-500'
         placeholder='정답을 입력해 주세요.'
         disabled={isSubmitted}
+        maxLength={255}
         onChange={(e) =>
           isSubmitted === false && shortAnswerHandler(e.target.value)
         }

--- a/src/util/toast/setUndevelopedAlertToast.ts
+++ b/src/util/toast/setUndevelopedAlertToast.ts
@@ -2,7 +2,7 @@ import toast from 'react-hot-toast';
 import Toast from '../../components/ui/Toast';
 import { TOAST_TIMEOUT } from '.';
 
-export default function setUndevelopedAlertToast() {
+export default function setUndevelopedAlertToast(id: string) {
   const undevelopedAlert: CustomToast = {
     type: 'undeveloped',
     title: '아직 개발 중이에요!',
@@ -11,9 +11,9 @@ export default function setUndevelopedAlertToast() {
   const param = {
     toast: undevelopedAlert
   };
-
+  
   toast.custom(() => Toast(param), {
-    id: 'undeveloped',
+    id: `undeveloped-${id}`,
     duration: TOAST_TIMEOUT,
     position: 'bottom-center',
     ariaProps: {

--- a/src/util/toast/setUndevelopedAlertToast.ts
+++ b/src/util/toast/setUndevelopedAlertToast.ts
@@ -1,0 +1,24 @@
+import toast from 'react-hot-toast';
+import Toast from '../../components/ui/Toast';
+import { TOAST_TIMEOUT } from '.';
+
+export default function setUndevelopedAlertToast() {
+  const undevelopedAlert: CustomToast = {
+    type: 'undeveloped',
+    title: '아직 개발 중이에요!',
+    description: '열심히 작업 중이니 조금만 기다려 주세요 :)'
+  };
+  const param = {
+    toast: undevelopedAlert
+  };
+
+  toast.custom(() => Toast(param), {
+    id: 'undeveloped',
+    duration: TOAST_TIMEOUT,
+    position: 'bottom-center',
+    ariaProps: {
+      role: 'status',
+      'aria-live': 'polite'
+    }
+  });
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -13,6 +13,7 @@ interface WeekRange {
 interface Emoji {
   lecture_enrollment: string;
   error: string;
+  undeveloped: string;
 }
 
 interface CustomToast {


### PR DESCRIPTION
## Motivation 🤔
- 배포 준비에 앞서, 모바일 이용자들에게 태블릿 및 PC 접속을 유도하기 위함

<br>

## Key changes ✅
### 모바일 해상도 차단
- 모바일 해상도(`500px`이하)로 접속하였을 경우, 페이지를 아래와 같이 대체합니다
- 랜딩 페이지 (메인 페이지)는 모바일로도 접근 가능합니다
![ezgif com-video-to-gif (19)](https://github.com/4m9d/sroom-fe/assets/63336701/634799c7-7a5e-4ccb-be2f-1aca5b63b6d4)

### 미개발 알림 토스트
- 아직 개발되지 않은 부분을 클릭했을 경우, 아래와 같은 토스트 메시지를 표시합니다
<img width="1307" alt="image" src="https://github.com/4m9d/sroom-fe/assets/63336701/ff6cff4f-845a-4623-b2f6-2c41fc3df24d">

### 사소한 수정사항들
- 일정 관리 모달에서 슬라이더 클릭 인식율을 개선했습니다
- 퀴즈 채점 결과 제출 시, 주관식 문제도 포함하도록 수정하였습니다

## To reviewers 🙏
- 예상치 못한 오류가 있으면 알려주세요
- 태블릿 / PC 접속 안내 문구가 적절한지 봐주세요