### PR TITLE
Feat/#81/naver analytics(swm 360)

### DIFF
--- a/src/app/@modal/(.)search/[lecture_code]/error.tsx
+++ b/src/app/@modal/(.)search/[lecture_code]/error.tsx
@@ -1,10 +1,10 @@
 'use client';
-import { API_FETCH_ERROR, ErrorMessage } from '@/src/api/ErrorMessage';
+import { API_FETCH_ERROR, ErrorMessage, SESSION_ERROR } from '@/src/api/ErrorMessage';
+import useAuth from '@/src/hooks/useAuth';
 import setErrorToast from '@/src/util/toast/setErrorToast';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
-export default function ErrorHandler({
+export default async function ErrorHandler({
   error,
   reset
 }: {
@@ -12,16 +12,17 @@ export default function ErrorHandler({
   reset: () => void;
 }) {
   const router = useRouter();
+  const { logout } = useAuth();
 
-  useEffect(() => {
     if (error.cause === API_FETCH_ERROR) {
       setErrorToast(error);
       router.back();
+    } else if (error.cause === SESSION_ERROR) {
+      setErrorToast(error);
+      await logout();
     } else {
       setErrorToast(new Error(ErrorMessage.DEFAULT));
     }
-    return () => router.refresh();
-  }, [error, router]);
 
   return null;
 }

--- a/src/app/@modal/(.)search/[lecture_code]/loading.tsx
+++ b/src/app/@modal/(.)search/[lecture_code]/loading.tsx
@@ -3,7 +3,7 @@ type Props = {};
 export default function Loading({}: Props) {
   return (
     <div className='fixed top-0 left-0 items-center justify-center w-full h-full bg-black opacity-30'>
-      <div className='absolute z-20 top-1/2 left-1/2 loading loading-spinner loading-lg text-sroom-brand' />
+      <div className='absolute z-60 top-1/2 left-1/2 loading loading-spinner loading-lg text-sroom-brand' />
     </div>
   );
 }

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,3 +1,3 @@
 export default function Default() {
-  return null;
+  return <></>;
 }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,9 +1,31 @@
-import React from 'react'
+'use client';
+import LoginButton from '@/src/components/login/LoginButton';
+import Button from '@/src/components/ui/button/Button';
+import { useRouter } from 'next/navigation';
 
-type Props = {}
+export default function Signin({}) {
+  const router = useRouter();
 
-export default function Signin({}: Props) {
   return (
-    <div>Signin</div>
-  )
+    <div className='flex bg-sroom-gray-200'>
+      <div className='max-w-[400px] mx-auto pt-60 pb-96'>
+        <h2 className='flex flex-col gap-2 mb-8 text-3xl font-bold text-sroom-black-400'>
+          <p>{'스룸의 기능은 로그인을 해야'}</p>
+          <p>{'이용하실 수 있어요 :)'}</p>
+        </h2>
+        <h3 className='mb-16 text-lg font-medium text-sroom-black-100'>
+          {'구글 로그인으로 간편하게 스룸을 이용해보세요!'}
+        </h3>
+        <LoginButton className='mb-5' buttonWidth={400} />
+        <Button
+          className='w-full text-sroom-white bg-sroom-brand'
+          onClick={() => {
+            router.replace('/');
+          }}
+        >
+          홈으로 가기
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/src/app/auth/signout/page.tsx
+++ b/src/app/auth/signout/page.tsx
@@ -1,9 +1,35 @@
-import React from 'react'
+'use client';
+import Button from '@/src/components/ui/button/Button';
+import useAuth from '@/src/hooks/useAuth';
+import { useRouter } from 'next/navigation';
 
-type Props = {}
+export default function Signout({}) {
+  const router = useRouter();
+  const { logout } = useAuth();
 
-export default function Signout({}: Props) {
   return (
-    <div>Signout</div>
-  )
+    <div className='flex bg-sroom-gray-200'>
+      <div className='max-w-md mx-auto pt-60 pb-96'>
+        <h2 className='flex flex-col gap-2 mb-8 text-3xl font-bold text-sroom-black-400'>
+          <p>{'지금 로그아웃 하시면'}</p>
+          <p>{'스룸의 기능을 이용하실 수 없어요! :('}</p>
+        </h2>
+        <h3 className='mb-16 text-lg font-medium text-sroom-black-100'>
+          {'이용 중이시던 서비스를 계속해서 즐겨보세요'}
+        </h3>
+        <Button
+          className='w-full mb-5 text-sroom-white bg-sroom-brand'
+          onClick={router.back}
+        >
+          돌아가기
+        </Button>
+        <Button
+          className='w-full border text-sroom-black-400 bg-sroom-white border-sroom-gray-500'
+          onClick={logout}
+        >
+          로그아웃 하기
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,10 +1,14 @@
 'use client';
-import { API_FETCH_ERROR, ErrorMessage } from '@/src/api/ErrorMessage';
+import {
+  API_FETCH_ERROR,
+  ErrorMessage,
+  SESSION_ERROR
+} from '@/src/api/ErrorMessage';
+import useAuth from '@/src/hooks/useAuth';
 import setErrorToast from '@/src/util/toast/setErrorToast';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
-export default function ErrorHandler({
+export default async function ErrorHandler({
   error,
   reset
 }: {
@@ -12,15 +16,16 @@ export default function ErrorHandler({
   reset: () => void;
 }) {
   const router = useRouter();
+  const { logout } = useAuth();
 
-  useEffect(() => {
-    if (error.cause === API_FETCH_ERROR) {
-      setErrorToast(error);
-    } else {
-      setErrorToast(new Error(ErrorMessage.DEFAULT));
-    }
-    return () => router.refresh();
-  }, [error, router]);
+  if (error.cause === API_FETCH_ERROR) {
+    setErrorToast(error);
+  } else if (error.cause === SESSION_ERROR) {
+    setErrorToast(error);
+    await logout();
+  } else {
+    setErrorToast(new Error(ErrorMessage.DEFAULT));
+  }
 
   return null;
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,10 +1,14 @@
 'use client';
 import setErrorToast from '@/src/util/toast/setErrorToast';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-import { API_FETCH_ERROR, ErrorMessage } from '../api/ErrorMessage';
+import {
+  API_FETCH_ERROR,
+  ErrorMessage,
+  SESSION_ERROR
+} from '../api/ErrorMessage';
+import useAuth from '../hooks/useAuth';
 
-export default function ErrorHandler({
+export default async function ErrorHandler({
   error,
   reset
 }: {
@@ -12,16 +16,17 @@ export default function ErrorHandler({
   reset: () => void;
 }) {
   const router = useRouter();
+  const { logout } = useAuth();
 
-  useEffect(() => {
-    if (error.cause === API_FETCH_ERROR) {
-      setErrorToast(error);
-      router.back();
-    } else {
-      setErrorToast(new Error(ErrorMessage.DEFAULT));
-    }
-    return () => router.refresh();
-  }, [error, router]);
+  if (error.cause === API_FETCH_ERROR) {
+    setErrorToast(error);
+    router.back();
+  } else if (error.cause === SESSION_ERROR) {
+    setErrorToast(error);
+    await logout();
+  } else {
+    setErrorToast(new Error(ErrorMessage.DEFAULT));
+  }
 
   return null;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import Footer from '../components/fnb/Footer';
 import ChannelTalk from '../components/tools/ChannelTalk/ChannelTalk';
 import ChannelTalkManager from '../components/tools/ChannelTalk/ChannelTalkManager';
 import GoogleAnalytics from '../components/tools/GoogleAnalytics/GoogleAnalytics';
+import NaverAnalytics from '../components/tools/NaverAnalytics/NaverAnalytics';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -42,6 +43,7 @@ export default function RootLayout({ children, modal }: Props) {
   return (
     <html lang='ko'>
       <GoogleAnalytics />
+      <NaverAnalytics />
       <ChannelTalk />
       <body className={inter.className}>
         <AuthSessionProvider>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,12 +6,12 @@ export default function NotFound({}) {
   const router = useRouter();
 
   return (
-    <div className='z-[9999] w-screen h-screen bg-white'>
-      <div className='max-w-md mx-auto mt-60'>
-        <h2 className='mb-8 text-4xl font-bold text-sroom-black-400'>
+    <div className='flex bg-sroom-gray-200'>
+      <div className='max-w-md mx-auto pt-60 pb-96'>
+        <h2 className='mb-8 text-3xl font-bold text-sroom-black-400'>
           {'해당 페이지를 찾을 수 없어요 :('}
         </h2>
-        <h3 className='mb-16 text-xl font-medium text-sroom-black-100'>
+        <h3 className='mb-16 text-lg font-medium text-sroom-black-100'>
           {'404 not found'}
         </h3>
         <Button

--- a/src/app/search/[lecture_code]/error.tsx
+++ b/src/app/search/[lecture_code]/error.tsx
@@ -1,10 +1,14 @@
 'use client';
-import { API_FETCH_ERROR, ErrorMessage } from '@/src/api/ErrorMessage';
+import {
+  API_FETCH_ERROR,
+  ErrorMessage,
+  SESSION_ERROR
+} from '@/src/api/ErrorMessage';
+import useAuth from '@/src/hooks/useAuth';
 import setErrorToast from '@/src/util/toast/setErrorToast';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
-export default function ErrorHandler({
+export default async function ErrorHandler({
   error,
   reset
 }: {
@@ -12,17 +16,18 @@ export default function ErrorHandler({
   reset: () => void;
 }) {
   const router = useRouter();
+  const { logout } = useAuth();
 
-  useEffect(() => {
-    if (error.cause === API_FETCH_ERROR) {
-      setErrorToast(error);
-      router.replace('/');
-      router.refresh();
-    } else {
-      setErrorToast(new Error(ErrorMessage.DEFAULT));
-    }
-    return () => router.refresh();
-  }, [error, router]);
+  if (error.cause === API_FETCH_ERROR) {
+    setErrorToast(error);
+    router.replace('/');
+    router.refresh();
+  } else if (error.cause === SESSION_ERROR) {
+    setErrorToast(error);
+    await logout();
+  } else {
+    setErrorToast(new Error(ErrorMessage.DEFAULT));
+  }
 
   return null;
 }

--- a/src/components/gnb/NavBar.tsx
+++ b/src/components/gnb/NavBar.tsx
@@ -10,6 +10,7 @@ import { useSession } from 'next-auth/react';
 import { useMutation } from '@tanstack/react-query';
 import { updateUserProfile } from '@/src/api/members/members';
 import ProfileDropdown from './ProfileDropdown';
+import { useRouter } from 'next/navigation';
 
 type Props = {
   logo: string;
@@ -18,7 +19,7 @@ type Props = {
 const WIDTH_SM = 640;
 
 export default function NavBar({ logo, profileDropdown }: Props) {
-  const { logout } = useAuth();
+  const router = useRouter();
   const { data: session, update } = useSession();
   const { width: windowWidth } = useWindowSize();
   const [isEditMode, setIsEditMode] = useState(false);
@@ -75,7 +76,7 @@ export default function NavBar({ logo, profileDropdown }: Props) {
           <SearchInput />
         </div>
         <Button
-          onClick={logout}
+          onClick={() => router.push('/auth/signout')}
           className={`${navBarHidden} g_id_signout w-20 lg:w-24 bg-sroom-brand`}
         >
           <p className='text-xs lg:text-sm text-sroom-white'>로그아웃</p>

--- a/src/components/lectureDetail/LectureDetailModal.tsx
+++ b/src/components/lectureDetail/LectureDetailModal.tsx
@@ -82,63 +82,65 @@ export default function LectureDetailModal({
           isIndexListFetched={isIndexListFetched}
         />
         <LectureDetailTabNav is_playlist={is_playlist} />
-        <section id='indexes'>
-          <LectureDetailHeading title={'목차'} />
-          {is_playlist ? (
-            <>
-              <Suspense
-                fallback={<LectureDetailIndexSkeleton limit={INDEX_LIMIT} />}
-              >
-                <LectureDetailIndexList
-                  lectureCode={lecture_code}
-                  setIsFetched={setIsIndexListFetched}
-                />
-              </Suspense>
-            </>
-          ) : (
-            indexes && (
+        <div id='lecture-detail-conatiner'>
+          <section id='indexes'>
+            <LectureDetailHeading title={'목차'} />
+            {is_playlist ? (
               <>
-                <LectureIndexNotice
-                  duration={lectureDetail.duration as number}
-                  lecture_count={1}
-                  hasMembersOnly={lectureDetail.is_members_only as boolean}
-                />
-                <LectureDetailIndexCard
-                  lectureIndex={indexes.index_list[0]}
-                  indexNum={1}
-                />
+                <Suspense
+                  fallback={<LectureDetailIndexSkeleton limit={INDEX_LIMIT} />}
+                >
+                  <LectureDetailIndexList
+                    lectureCode={lecture_code}
+                    setIsFetched={setIsIndexListFetched}
+                  />
+                </Suspense>
               </>
-            )
-          )}
-        </section>
-        <section id='reviews'>
-          <LectureDetailHeading title={'후기'}>
-            <div className='flex items-center justify-center gap-1 ml-1'>
-              <p>{`(${lectureDetail.review_count})`}</p>
-              {lectureDetail.review_count > 0 && (
+            ) : (
+              indexes && (
                 <>
-                  <OneStar className='w-4 h-4' />
-                  <p className='text-base font-medium text-sroom-brand'>
-                    {rating}
-                  </p>
+                  <LectureIndexNotice
+                    duration={lectureDetail.duration as number}
+                    lecture_count={1}
+                    hasMembersOnly={lectureDetail.is_members_only as boolean}
+                  />
+                  <LectureDetailIndexCard
+                    lectureIndex={indexes.index_list[0]}
+                    indexNum={1}
+                  />
                 </>
-              )}
-            </div>
-          </LectureDetailHeading>
-          <Suspense
-            fallback={
-              <LectureDetailReviewSkeleton
+              )
+            )}
+          </section>
+          <section id='reviews'>
+            <LectureDetailHeading title={'후기'}>
+              <div className='flex items-center justify-center gap-1 ml-1'>
+                <p>{`(${lectureDetail.review_count})`}</p>
+                {lectureDetail.review_count > 0 && (
+                  <>
+                    <OneStar className='w-5 h-5' />
+                    <p className='text-base font-medium text-sroom-brand'>
+                      {rating}
+                    </p>
+                  </>
+                )}
+              </div>
+            </LectureDetailHeading>
+            <Suspense
+              fallback={
+                <LectureDetailReviewSkeleton
+                  reviewPageRef={reviewPageRef}
+                  limit={REVIEW_LIMIT}
+                />
+              }
+            >
+              <LectureDetailReviewList
                 reviewPageRef={reviewPageRef}
-                limit={REVIEW_LIMIT}
+                lectureCode={lecture_code}
               />
-            }
-          >
-            <LectureDetailReviewList
-              reviewPageRef={reviewPageRef}
-              lectureCode={lecture_code}
-            />
-          </Suspense>
-        </section>
+            </Suspense>
+          </section>
+        </div>
       </Modal>
       {is_playlist && isIndexListFetched === true && (
         <>

--- a/src/components/lectureDetail/LectureDetailModal.tsx
+++ b/src/components/lectureDetail/LectureDetailModal.tsx
@@ -7,10 +7,7 @@ import LectureDetailIndexList from './index/LectureDetailIndexList';
 import LectureDetailReviewList from './review/LectureDetailReviewList';
 import LectureDetailCard from './LectureDetailCard';
 import LectureDetailIndexSkeleton from './index/LectureDetailIndexSkeleton';
-import {
-  INDEX_LIMIT,
-  REVIEW_LIMIT
-} from '@/src/constants/skeleton/skeleton';
+import { INDEX_LIMIT, REVIEW_LIMIT } from '@/src/constants/skeleton/skeleton';
 import LectureDetailHeading from './LectureDetailHeading';
 import LectureDetailReviewSkeleton from './review/LectureDetailReviewSkeleton';
 import OneStar from '../ui/rating/OneStar';
@@ -36,9 +33,14 @@ export default function LectureDetailModal({
   const [isIndexListFetched, setIsIndexListFetched] = useState<boolean>(false);
 
   const onCloseHandler = useCallback(() => {
-    return navigationType === 'soft'
-      ? router.back()
-      : router.push('/dashboard');
+    if (navigationType === 'soft') {
+      return closeModalHandler('LECTURE_DETAIL', router.back);
+    } else {
+      return closeModalHandler('LECTURE_DETAIL', () => {
+        router.replace('/dashboard');
+        router.refresh();
+      });
+    }
   }, [navigationType, router]);
 
   const isTheOnlyModalInPage = () => {

--- a/src/components/lectureDetail/LectureDetailTabNav.tsx
+++ b/src/components/lectureDetail/LectureDetailTabNav.tsx
@@ -2,6 +2,7 @@
 import TabNav from '../ui/TabNav';
 import { useEffect, useState } from 'react';
 import useIntersectionObserver from '@/src/hooks/useIntersectionObserver';
+import Link from 'next/link';
 
 type Props = {
   is_playlist: boolean;
@@ -15,7 +16,7 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
     setActiveId,
     document.getElementById('modal')
   );
-  
+
   useEffect(() => {
     const entries = document.querySelectorAll('section');
     entries.forEach((entry) => observe(entry));
@@ -25,21 +26,23 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
 
   return (
     <TabNav className='sticky z-10 h-16 border-b tab-bordered border-b-sroom-black-100 -top-14 bg-sroom-white text-sroom-black-400'>
-        <li>
-          <a
-            href='#indexes'
-            className={`tab tab-bordered text-lg transition-colors p-1 ${
-              activeId === 'indexes'
-                ? 'tab-active font-bold border-b-sroom-black-400 border-b-2'
-                : 'border-none text-sroom-black-100 font-medium'
-            }`}
-          >
-            목차
-          </a>
-        </li>
       <li>
-        <a
+        <Link
+          href='#indexes'
+          replace={true}
+          className={`tab tab-bordered text-lg transition-colors p-1 ${
+            activeId === 'indexes'
+              ? 'tab-active font-bold border-b-sroom-black-400 border-b-2'
+              : 'border-none text-sroom-black-100 font-medium'
+          }`}
+        >
+          목차
+        </Link>
+      </li>
+      <li>
+        <Link
           href='#reviews'
+          replace={true}
           className={`tab tab-bordered text-lg transition-colors ml-3 p-1 ${
             activeId === 'reviews'
               ? 'tab-active font-bold border-b-sroom-black-400 border-b-2'
@@ -47,7 +50,7 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
           }`}
         >
           후기
-        </a>
+        </Link>
       </li>
     </TabNav>
   );

--- a/src/components/lectureDetail/LectureDetailTabNav.tsx
+++ b/src/components/lectureDetail/LectureDetailTabNav.tsx
@@ -14,11 +14,14 @@ export default function LectureDetailTabNav({ is_playlist }: Props) {
   );
   const [observe, unobserve] = useIntersectionObserver(
     setActiveId,
-    document.getElementById('modal')
+    document.querySelector('#lecture-detail-container')
   );
 
   useEffect(() => {
-    const entries = document.querySelectorAll('section');
+    const entries = document.querySelectorAll(
+      'dialog section'
+    ) as NodeListOf<HTMLElement>;
+
     entries.forEach((entry) => observe(entry));
 
     return () => entries.forEach((entry) => unobserve(entry));

--- a/src/components/lectureDetail/review/LectureDetailReviewList.tsx
+++ b/src/components/lectureDetail/review/LectureDetailReviewList.tsx
@@ -27,9 +27,9 @@ export default async function LectureDetailReviewList({
     lastPage: LectureReviewList | null,
     allPages: (LectureReviewList | null)[]
   ) => {
-    return lastPage && lastPage.length > 0
-      ? allPages.length * lastPage.length
-      : 0;
+    if (lastPage === null || lastPage.length === 0) return undefined;
+    
+    return allPages.length * lastPage.length;
   };
 
   const fetchLectureReviewList = async ({ pageParam: offset = 0 }) => {

--- a/src/components/login/LoginButton.tsx
+++ b/src/components/login/LoginButton.tsx
@@ -1,11 +1,16 @@
 'use client';
-import { memo, useRef } from 'react';
+import { useRef } from 'react';
 import useAuth from '@/src/hooks/useAuth';
 import Script from 'next/script';
 import useWindowSize from '@/src/hooks/useWindowSize';
 import { BROWSER_MIN_WIDTH } from '@/src/constants/window/window';
 
-function LoginButton() {
+type Props = {
+  className?: string;
+  buttonWidth?: number;
+};
+
+export default function LoginButton({ className, buttonWidth: width = 100 }: Props) {
   const loginButton = useRef<HTMLDivElement>(null);
   const { login, status } = useAuth();
   const { width: windowWidth } = useWindowSize();
@@ -24,7 +29,7 @@ function LoginButton() {
 
     window.google.accounts.id.renderButton(loginButton.current, {
       theme: 'outline',
-      width: 100
+      width: width
     });
   };
 
@@ -39,7 +44,7 @@ function LoginButton() {
             defer
           />
           <div
-            className='inline-block h-10 mt-2 align-middle md:mt-5'
+            className={`${className} inline-block h-10 mt-2 align-middle md:mt-5`}
             id='google-login-button'
             ref={loginButton}
           />
@@ -48,5 +53,3 @@ function LoginButton() {
     </>
   );
 }
-
-export default memo(LoginButton);

--- a/src/components/recommendations/LectureRecommendationsList.tsx
+++ b/src/components/recommendations/LectureRecommendationsList.tsx
@@ -61,7 +61,7 @@ export default function LectureRecommendationsList() {
   return (
     <>
       {recommendations.length > 0 && (
-        <section className='px-4 mx-auto my-20 lg:px-24 max-w-screen-2xl'>
+        <section className='px-4 mx-auto my-20 lg:px-24 max-w-screen-2xl min-h-12'>
           <SectionHeading title='이런 강의는 어때요?' />
           <div className='relative'>
             <Swiper

--- a/src/components/tools/NaverAnalytics/NaverAnalytics.tsx
+++ b/src/components/tools/NaverAnalytics/NaverAnalytics.tsx
@@ -1,0 +1,22 @@
+import Script from 'next/script';
+
+export default function NaverAnalytics({}) {
+  return (
+    <>
+      <Script type='text/javascript' src='//wcs.naver.net/wcslog.js'></Script>
+      <Script
+        id='naver-analytics-init'
+        type='text/javascript'
+        dangerouslySetInnerHTML={{
+          __html: `
+          if(!wcs_add) var wcs_add = {};
+          wcs_add["wa"] = "2a95c9953db4ac";
+          if(window.wcs) {
+            wcs_do();
+          }
+          `
+        }}
+      ></Script>
+    </>
+  );
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -72,20 +72,19 @@ export default function useAuth() {
       redirect: false
     })
       .then((res) => {
+        router.refresh();
         if (res?.error) {
           throw new Error(ErrorMessage.LOGIN);
         }
-        router.push('/dashboard');
       })
       .catch((err) => {
         setErrorToast(err);
       });
-    router.refresh();
   };
 
   const logout = async () => {
     await signOut().then(() => {
-      router.push('/');
+      router.refresh();
     });
   };
 

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,12 +1,12 @@
 import { useCallback, useRef } from 'react';
 
 export default function useIntersectionObserver(
-  setId: (id: string) => void,
+  setId: React.Dispatch<React.SetStateAction<string>>,
   root: HTMLElement | null,
   rootMargin?: string
 ) {
   const option = {
-    threshold: [0.1, 0.9],
+    threshold: [0.1, 0.5, 0.9],
     root,
     rootMargin
   };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,9 @@ const secret = process.env.NEXTAUTH_SECRET;
 function redirectToMain(req: NextRequest) {
   return NextResponse.redirect(new URL('/', req.url));
 }
+function redirectToSignin(req: NextRequest) {
+  return NextResponse.rewrite(new URL('/auth/signin', req.url));
+}
 function redirectToDashboard(req: NextRequest) {
   return NextResponse.redirect(new URL('/dashboard', req.url));
 }
@@ -25,14 +28,14 @@ export async function middleware(req: NextRequest) {
     if (pathname === '/') {
       return redirectToDashboard(req);
     }
-    //NOTE: 로그인 상태에서 로그인 페이지로 접근하면 메인 페이지로 리다이렉트F
+    //NOTE: 로그인 상태에서 로그인 페이지로 접근하면 메인 페이지로 리다이렉트
     if (pathname === '/auth/signin') {
       return redirectToMain(req);
     }
   } else if (authenticated === false) {
-    //NOTE: 로그아웃 상태에서는 메인 페이지만 접근 가능
+    //NOTE: 로그아웃 상태에서는 로그인 페이지로 리다이렉트
     if (tryToAccessProtectedRoute(pathname)) {
-      return redirectToMain(req);
+      return redirectToSignin(req);
     }
     //NOTE: 로그아웃 상태에서 로그아웃 페이지로 접근하면 메인 페이지로 리다이렉트
     if (pathname === '/auth/signout') {


### PR DESCRIPTION
## Motivation 🤔
- 양질의 사용자 분석을 위함

<br>

## Key changes ✅
### 네이버 애널리틱스 도입
- html에 네이버 애널리틱스를 위한 스크립트를 추가했습니다
### 로그인 및 로그아웃 플로우 개선
- 로그인이 되지 않은 상태에서 `'/'`이 아닌 하위 페이지를 접근하려 할 때, `'/'`로 리다이렉트 -> `/auth/signin`을 거쳐서 로그인 후 원래 접속하려던 페이지로 리다이렉트하는 방식으로 수정
- 상단바의 로그아웃 버튼을 누르면 즉시 로그아웃 -> `/auth/signout`을 거쳐 로그아웃 확인 및 로그인 유지를 유도하는 방식으로 수정
  ![ezgif com-video-to-gif (24)](https://github.com/4m9d/sroom-fe/assets/63336701/4a203c95-2fc8-4ab5-a72a-d7a08898df55)
### 자잘한 오류 수정
- 강의 상세 모달 탭 전환 개선
  ![ezgif com-video-to-gif (23)](https://github.com/4m9d/sroom-fe/assets/63336701/f523d675-8fee-4395-baab-5781e64d70e9)
- 강의 상세 모달에서 `후기 더보기` 버튼을 클릭할 때 기존 데이터가 중복으로 쌓이던 오류 수정

<br>

## To reviewers 🙏
- 상세 모달 탭 전환 오류가 여전히 발생하는 조건이 존재하는지 확인해주세요...!