### PR TITLE
Improve/#89/user flow(swm 390)

### DIFF
--- a/src/components/classroom/delete/CourseDeleteModal.tsx
+++ b/src/components/classroom/delete/CourseDeleteModal.tsx
@@ -46,14 +46,14 @@ export default function CourseDeleteModal({ courseId, courseTitle }: Props) {
         <div className='flex items-center justify-between w-full gap-5 mt-8'>
           <Button
             onClick={() => closeModalHandler('COURSE_DELETE')}
-            className='w-1/2 text-sroom-white bg-sroom-black-400'
+            className='w-1/2 text-sroom-white bg-sroom-brand'
           >
-            뒤로가기
+            취소하기
           </Button>
           <Button
             disabled={isDisabled}
             onClick={mutate}
-            className='w-1/2 text-sroom-white bg-sroom-brand'
+            className='w-1/2 text-sroom-white bg-sroom-black-400'
           >
             {isDisabled ? (
               <LoadingSpinner className='text-sroom-white loading-sm' />

--- a/src/components/classroom/review/CourseReviewModal.tsx
+++ b/src/components/classroom/review/CourseReviewModal.tsx
@@ -150,12 +150,14 @@ export default function CourseReviewModal({ courseId }: Props) {
                     onClick={stateInitHandler}
                     className='w-1/2 text-sroom-black-400 bg-sroom-gray-400'
                   >
-                    뒤로가기
+                    목록보기
                   </Button>
                   <Button
                     disabled={isDisabled}
                     onClick={mutate}
-                    className='w-1/2 text-sroom-white bg-sroom-black-400'
+                    className={`w-1/2 text-sroom-white bg-sroom-black-400 ${
+                      isDisabled ? 'opacity-60' : ''
+                    }`}
                   >
                     {mutateStatus === 'loading' ? (
                       <LoadingSpinner className='text-sroom-brand loading-sm' />

--- a/src/components/course/CourseHeader.tsx
+++ b/src/components/course/CourseHeader.tsx
@@ -38,7 +38,7 @@ export default function CourseHeader({ title, channel, is_completed }: Props) {
         <div className='flex flex-col justify-end shrink-0'>
           <Button
             id='course-material-drawer'
-            className='text-xs md:text-sm px-4 md:!px-8 font-bold text-sroom-white bg-sroom-black-400'
+            className='text-xs md:text-sm px-4 md:!px-8 font-bold text-sroom-white bg-sroom-black-400 animate-pulse'
           >
             {'강의 자료 보기'}
           </Button>

--- a/src/components/course/CourseTaking.tsx
+++ b/src/components/course/CourseTaking.tsx
@@ -120,7 +120,11 @@ export default function CourseTaking({
     ) {
       showModalHandler('LECTURE_REVIEW');
     }
-  });
+  }, [
+    currentCourseVideoId,
+    currentPlayingVideo.is_completed,
+    lastVideoInCourse.course_video_id
+  ]);
 
   return (
     <div className='flex items-stretch flex-1 h-[calc(100vh-4rem)] bg-sroom-gray-200'>

--- a/src/components/course/CourseTaking.tsx
+++ b/src/components/course/CourseTaking.tsx
@@ -119,10 +119,7 @@ export default function CourseTaking({
   }, [searchPrevVideo, searchNextVideo]);
 
   useEffect(() => {
-    if (
-      currentCourseVideoId === lastVideoInCourse.course_video_id &&
-      currentPlayingVideo.is_completed === true
-    ) {
+    if (courseDetail.progress === 100) {
       queryClient.invalidateQueries([
         QueryKeys.LECTURE_REVIEW,
         courseDetail.course_id.toString()
@@ -135,19 +132,15 @@ export default function CourseTaking({
         if (
           reviewableList.lectures.find(
             (lecture) => lecture.is_review_allowed === true
-          ) &&
-          courseDetail.progress >= 50
+          )
         ) {
           showModalHandler('LECTURE_REVIEW');
         }
       }, 1 * ONE_SECOND_IN_MS);
     }
   }, [
-    currentCourseVideoId,
     courseDetail.course_id,
     courseDetail.progress,
-    currentPlayingVideo.is_completed,
-    lastVideoInCourse.course_video_id,
     queryClient
   ]);
 

--- a/src/components/course/CourseTaking.tsx
+++ b/src/components/course/CourseTaking.tsx
@@ -6,6 +6,8 @@ import CourseDetailDrawer from './drawer/courseDetail/CourseDetailDrawer';
 import CourseMaterialDrawer from './drawer/courseMaterial/CourseMaterialDrawer';
 import CourseVideoController from './CourseVideoController';
 import { SessionStorageKeys } from '@/src/constants/courseTaking/courseTaking';
+import CourseReviewModal from '../classroom/review/CourseReviewModal';
+import { showModalHandler } from '@/src/util/modal/modalHandler';
 
 type Props = {
   courseDetail: CourseDetail;
@@ -18,6 +20,10 @@ export default function CourseTaking({
 }: Props) {
   const last_view_video = findVideoById() as LastViewVideo;
   const currentPlayingVideo = last_view_video;
+  const lastVideoInCourse =
+    courseDetail.sections[courseDetail.sections.length - 1].videos[
+      courseDetail.sections[courseDetail.sections.length - 1].videos.length - 1
+    ];
 
   const [prevPlayingVideo, setPrevPlayingVideo] =
     useState<LastViewVideo | null>(last_view_video);
@@ -107,6 +113,15 @@ export default function CourseTaking({
     searchNextVideo();
   }, [searchPrevVideo, searchNextVideo]);
 
+  useEffect(() => {
+    if (
+      currentCourseVideoId === lastVideoInCourse.course_video_id &&
+      currentPlayingVideo.is_completed === true
+    ) {
+      showModalHandler('LECTURE_REVIEW');
+    }
+  });
+
   return (
     <div className='flex items-stretch flex-1 h-[calc(100vh-4rem)] bg-sroom-gray-200'>
       <CourseDetailDrawer
@@ -143,6 +158,7 @@ export default function CourseTaking({
         </div>
       </div>
       <CourseMaterialDrawer courseVideoId={currentCourseVideoId} />
+      <CourseReviewModal courseId={courseDetail.course_id} />
     </div>
   );
 }

--- a/src/components/course/CourseTaking.tsx
+++ b/src/components/course/CourseTaking.tsx
@@ -135,7 +135,8 @@ export default function CourseTaking({
         if (
           reviewableList.lectures.find(
             (lecture) => lecture.is_review_allowed === true
-          )
+          ) &&
+          courseDetail.progress >= 50
         ) {
           showModalHandler('LECTURE_REVIEW');
         }
@@ -144,6 +145,7 @@ export default function CourseTaking({
   }, [
     currentCourseVideoId,
     courseDetail.course_id,
+    courseDetail.progress,
     currentPlayingVideo.is_completed,
     lastVideoInCourse.course_video_id,
     queryClient

--- a/src/components/course/CourseVideoController.tsx
+++ b/src/components/course/CourseVideoController.tsx
@@ -49,7 +49,7 @@ export default function CourseVideoController({
     updateIsCompletedManually,
     {
       onSuccess: (data) => {
-        setVideoCompleteToast();
+        setVideoCompleteToast(course_video_id);
         data && setIsCompleted(data.is_completed);
 
         if (currentIntervalID.current !== null) {

--- a/src/components/course/drawer/courseMaterial/CourseMaterialDrawer.tsx
+++ b/src/components/course/drawer/courseMaterial/CourseMaterialDrawer.tsx
@@ -150,12 +150,18 @@ export default function CourseMaterialDrawer({ courseVideoId }: Props) {
   };
 
   const drawerHandler = useCallback(() => {
+    const buttonElement = document.getElementById(
+      'course-material-drawer'
+    ) as HTMLButtonElement;
+
     if (isDrawerOpen) {
       controls.start('exit');
       setIsDrawerOpen(false);
+      buttonElement.classList.add('animate-pulse');
     } else {
       controls.start('animate');
       setIsDrawerOpen(true);
+      buttonElement.classList.remove('animate-pulse');
     }
   }, [controls, isDrawerOpen]);
 

--- a/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewCard.tsx
+++ b/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewCard.tsx
@@ -1,15 +1,17 @@
 'use client';
 import Button from '@/src/components/ui/button/Button';
 import getRelativeTime from '@/src/util/time/getRelativeTime';
-import { useState } from 'react';
 
 type Props = {
   wrongQuiz: WrongQuiz;
+  mode: 'question' | 'answer';
+  setMode: React.Dispatch<React.SetStateAction<'question' | 'answer'>>;
 };
 type ChildProps = {
   title: string;
   buttonLabel: string;
   description: string;
+  mode: 'question' | 'answer';
   toggleModeHandler: () => void;
 };
 
@@ -17,16 +19,20 @@ function WrongQuizContent({
   title,
   buttonLabel,
   description,
+  mode,
   toggleModeHandler
 }: ChildProps) {
   return (
     <>
       <div className='items-center justify-between hidden mb-1 border-b-2 sm:flex border-b-sroom-white'>
-        <p className='text-xs whitespace-normal text-sroom-gray-100 line-clamp-1'>{title}</p>
+        <p className='text-xs whitespace-normal text-sroom-gray-100 line-clamp-1'>
+          {title}
+        </p>
         <Button
           onClick={toggleModeHandler}
-          className='h-[1.15rem] border !rounded-full w-16 bg-sroom-white text-sroom-brand
-              mb-1 text-xs'
+          className={`h-[1.15rem] border !rounded-full w-16 bg-sroom-white mb-1 text-xs ${
+            mode === 'question' ? 'text-sroom-brand' : 'text-sroom-black-200'
+          }`}
         >
           {buttonLabel}
         </Button>
@@ -38,9 +44,11 @@ function WrongQuizContent({
   );
 }
 
-export default function WrongQuizReviewCard({ wrongQuiz }: Props) {
-  const [mode, setMode] = useState<'question' | 'answer'>('question');
-
+export default function WrongQuizReviewCard({
+  wrongQuiz,
+  mode,
+  setMode
+}: Props) {
   const toggleModeHandler = () => {
     setMode((prev) => (prev === 'question' ? 'answer' : 'question'));
   };
@@ -52,6 +60,7 @@ export default function WrongQuizReviewCard({ wrongQuiz }: Props) {
           title={wrongQuiz.video_title}
           buttonLabel='정답보기'
           description={`Q. ${wrongQuiz.quiz_question}`}
+          mode={mode}
           toggleModeHandler={toggleModeHandler}
         />
       ) : mode === 'answer' ? (
@@ -59,6 +68,7 @@ export default function WrongQuizReviewCard({ wrongQuiz }: Props) {
           title={getRelativeTime(wrongQuiz.submitted_at)}
           buttonLabel='문제보기'
           description={`A. ${wrongQuiz.quiz_answer}`}
+          mode={mode}
           toggleModeHandler={toggleModeHandler}
         />
       ) : (

--- a/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewSlider.tsx
+++ b/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewSlider.tsx
@@ -18,6 +18,7 @@ export default function WrongQuizReviewSlider({ wrongQuizzes }: Props) {
   const [isFirstSlide, setIsFirstSlide] = useState<boolean>(true);
   const [isLastSlide, setIsLastSlide] = useState<boolean>(false);
   const [currPageIdx, setCurrPageIdx] = useState(1);
+  const [mode, setMode] = useState<'question' | 'answer'>('question');
 
   const totalPage = wrongQuizzes.length;
 
@@ -35,7 +36,15 @@ export default function WrongQuizReviewSlider({ wrongQuizzes }: Props) {
   }, [totalPage, currPageIdx]);
 
   return (
-    <div className='flex items-center col-start-1 col-end-3 row-start-1 row-end-2 px-[5%] rounded-full bg-sroom-brand relative'>
+    <div
+      className={`flex items-center col-start-1 col-end-3 row-start-1 row-end-2 px-[5%] rounded-full relative ${
+        mode === 'question'
+          ? 'bg-sroom-brand'
+          : 'answer'
+          ? 'bg-sroom-black-200'
+          : ''
+      }`}
+    >
       {wrongQuizzes.length > 0 && (
         <>
           <Swiper
@@ -55,8 +64,15 @@ export default function WrongQuizReviewSlider({ wrongQuizzes }: Props) {
             }}
           >
             {wrongQuizzes.map((wrongQuiz, idx) => (
-              <SwiperSlide key={idx} className='self-center h-full p-1 whitespace-normal'>
-                <WrongQuizReviewCard wrongQuiz={wrongQuiz} />
+              <SwiperSlide
+                key={idx}
+                className='self-center h-full p-1 whitespace-normal'
+              >
+                <WrongQuizReviewCard
+                  wrongQuiz={wrongQuiz}
+                  mode={mode}
+                  setMode={setMode}
+                />
               </SwiperSlide>
             ))}
           </Swiper>

--- a/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewSlider.tsx
+++ b/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewSlider.tsx
@@ -99,7 +99,7 @@ export default function WrongQuizReviewSlider({ wrongQuizzes }: Props) {
         </>
       )}
       {wrongQuizzes.length === 0 && (
-        <p className='flex items-center text-xs font-medium break-keep md:text-sm xl:text-base text-sroom-white'>
+        <p className='flex items-center text-xs font-medium break-keep md:text-sm xl:text-base text-sroom-white animate-pulse'>
           {'틀린 퀴즈가 생기면, 여기서 복습할 수 있어요 :)'}
         </p>
       )}

--- a/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewSlider.tsx
+++ b/src/components/dashboard/main/wrongQuizReview/WrongQuizReviewSlider.tsx
@@ -79,13 +79,19 @@ export default function WrongQuizReviewSlider({ wrongQuizzes }: Props) {
           <div className='absolute left-0 flex items-center justify-between w-full -translate-y-1/2 md:px-2 top-1/2'>
             <SwiperNavigationButton
               className='rounded-full text-sroom-white'
-              onClick={() => swiper?.slidePrev()}
+              onClick={() => {
+                swiper?.slidePrev();
+                setMode('question');
+              }}
               disabled={isFirstSlide}
               navigation='prev'
             />
             <SwiperNavigationButton
               className='rounded-full text-sroom-white'
-              onClick={() => swiper?.slideNext()}
+              onClick={() => {
+                swiper?.slideNext();
+                setMode('question');
+              }}
               disabled={isLastSlide}
               navigation='next'
             />

--- a/src/components/gnb/ProfileDropdown.tsx
+++ b/src/components/gnb/ProfileDropdown.tsx
@@ -43,6 +43,13 @@ export default function ProfileDropdown({
     [profileButtonClickHandler]
   );
 
+  const onBlurHandler = useCallback(() => {
+    setIsEditMode(false);
+    if (inputRef.current) {
+      inputRef.current.value = name;
+    }
+  }, [setIsEditMode, name]);
+
   const saveProfileButtonClickHandler = useCallback(async () => {
     if (inputRef.current && isEditMode) {
       inputRef.current.value = inputRef.current.value.trim().slice(0, 10) ?? '';
@@ -93,6 +100,7 @@ export default function ProfileDropdown({
           <input
             ref={inputRef}
             type='text'
+            onBlur={onBlurHandler}
             defaultValue={name}
             disabled={isEditMode === false}
             spellCheck='false'

--- a/src/components/lectureDetail/LectureDetailModal.tsx
+++ b/src/components/lectureDetail/LectureDetailModal.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import Modal from '../ui/Modal';
 import LectureDetailTabNav from './LectureDetailTabNav';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
@@ -29,19 +29,24 @@ export default function LectureDetailModal({
 }: Props) {
   const { is_playlist, lecture_code, rating, indexes } = lectureDetail;
   const router = useRouter();
+  const pathname = usePathname();
   const reviewPageRef = useRef<number>(0);
   const [isIndexListFetched, setIsIndexListFetched] = useState<boolean>(false);
 
   const onCloseHandler = useCallback(() => {
     if (navigationType === 'soft') {
-      return closeModalHandler('LECTURE_DETAIL', router.back);
+      if (pathname.includes('search')) {
+        return closeModalHandler('LECTURE_DETAIL', router.back);
+      } else {
+        return closeModalHandler('LECTURE_DETAIL');
+      }
     } else {
       return closeModalHandler('LECTURE_DETAIL', () => {
         router.replace('/dashboard');
         router.refresh();
       });
     }
-  }, [navigationType, router]);
+  }, [navigationType, router, pathname]);
 
   const isTheOnlyModalInPage = () => {
     return document.querySelectorAll('dialog[open]').length === 1;

--- a/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
+++ b/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
@@ -74,7 +74,7 @@ export default function LectureEnrollmentButton({
         const navigateToCourseTaking = setTimeout(() => {
           router.push(`/course/${response.course_id}`);
         }, 5 * ONE_SECOND_IN_MS);
-        setLectureEnrollToast(() => {
+        setLectureEnrollToast(lecture_code, () => {
           clearTimeout(navigateToCourseTaking);
           toast.remove('lecture_enrollment');
         });

--- a/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
+++ b/src/components/lectureEnrollment/LectureEnrollmentButton.tsx
@@ -14,6 +14,8 @@ import LoadingSpinner from '../ui/LoadingSpinner';
 import setLectureEnrollToast from '@/src/util/toast/setLectureEnrollToast';
 import { useRouter } from 'next/navigation';
 import { QueryKeys } from '@/src/api/queryKeys';
+import { ONE_SECOND_IN_MS } from '@/src/constants/time/time';
+import toast from 'react-hot-toast';
 
 type Props = {
   is_playlist: boolean;
@@ -68,10 +70,15 @@ export default function LectureEnrollmentButton({
   const { mutate, isLoading } = useMutation(enrollLecture, {
     onSuccess: (response) => {
       onEnrollSuccess();
-      response &&
-        setLectureEnrollToast(() =>
-          router.push(`/course/${response.course_id}`)
-        );
+      if (response) {
+        const navigateToCourseTaking = setTimeout(() => {
+          router.push(`/course/${response.course_id}`);
+        }, 5 * ONE_SECOND_IN_MS);
+        setLectureEnrollToast(() => {
+          clearTimeout(navigateToCourseTaking);
+          toast.remove('lecture_enrollment');
+        });
+      }
       queryClient.invalidateQueries([QueryKeys.DETAIL, lecture_code]);
     }
   });

--- a/src/components/lectureEnrollment/LectureEnrollmentModal.tsx
+++ b/src/components/lectureEnrollment/LectureEnrollmentModal.tsx
@@ -11,6 +11,8 @@ import LoadingSpinner from '../ui/LoadingSpinner';
 import setLectureEnrollToast from '@/src/util/toast/setLectureEnrollToast';
 import { useRouter } from 'next/navigation';
 import { QueryKeys } from '@/src/api/queryKeys';
+import { ONE_SECOND_IN_MS } from '@/src/constants/time/time';
+import toast from 'react-hot-toast';
 
 type Props = {
   lectureDetail: LectureDetail;
@@ -47,10 +49,15 @@ export default function LectureEnrollmentModal({
   const { mutate, isLoading } = useMutation(enrollLecture, {
     onSuccess: (response) => {
       onEnrollSuccess();
-      response &&
-        setLectureEnrollToast(() =>
-          router.push(`/course/${response.course_id}`)
-        );
+      if (response) {
+        const navigateToCourseTaking = setTimeout(() => {
+          router.push(`/course/${response.course_id}`);
+        }, 5 * ONE_SECOND_IN_MS);
+        setLectureEnrollToast(() => {
+          clearTimeout(navigateToCourseTaking);
+          toast.remove('lecture_enrollment');
+        });
+      }
       queryClient.invalidateQueries([QueryKeys.DETAIL, lecture_code]);
     }
   });

--- a/src/components/lectureEnrollment/LectureEnrollmentModal.tsx
+++ b/src/components/lectureEnrollment/LectureEnrollmentModal.tsx
@@ -53,7 +53,7 @@ export default function LectureEnrollmentModal({
         const navigateToCourseTaking = setTimeout(() => {
           router.push(`/course/${response.course_id}`);
         }, 5 * ONE_SECOND_IN_MS);
-        setLectureEnrollToast(() => {
+        setLectureEnrollToast(lecture_code, () => {
           clearTimeout(navigateToCourseTaking);
           toast.remove('lecture_enrollment');
         });

--- a/src/components/lectureEnrollment/SchedulingModal.tsx
+++ b/src/components/lectureEnrollment/SchedulingModal.tsx
@@ -9,6 +9,7 @@ import getFormattedTime from '@/src/util/time/getFormattedTime';
 import convertSecondsToMinutes from '@/src/util/time/convertSecondsToMinutes';
 import {
   FOUR_HOURS_IN_MINUTES,
+  ONE_SECOND_IN_MS,
   THIRTY_MINUTES
 } from '@/src/constants/time/time';
 import getCurrentDate from '@/src/util/day/getCurrentDate';
@@ -22,6 +23,7 @@ import getCompactDateFormat from '@/src/util/day/getCompactFormattedDate';
 import setLectureEnrollToast from '@/src/util/toast/setLectureEnrollToast';
 import { useRouter } from 'next/navigation';
 import { QueryKeys } from '@/src/api/queryKeys';
+import toast from 'react-hot-toast';
 
 type Props = {
   lectureDetail: LectureDetail;
@@ -60,10 +62,15 @@ export default function SchedulingModal({
   const { mutate, isLoading } = useMutation(enrollLecture, {
     onSuccess: (response) => {
       onEnrollSuccess();
-      response &&
-        setLectureEnrollToast(() =>
-          router.push(`/course/${response.course_id}`)
-        );
+      if (response) {
+        const navigateToCourseTaking = setTimeout(() => {
+          router.push(`/course/${response.course_id}`);
+        }, 5 * ONE_SECOND_IN_MS);
+        setLectureEnrollToast(() => {
+          clearTimeout(navigateToCourseTaking);
+          toast.remove('lecture_enrollment');
+        });
+      }
       queryClient.invalidateQueries([
         QueryKeys.DETAIL,
         lectureDetail.lecture_code
@@ -128,7 +135,7 @@ export default function SchedulingModal({
         } else {
           if (currWeekVideoCount === 0) {
             currWeekVideoCount++;
-            
+
             schedulingList.push(currWeekVideoCount);
             currWeekVideoCount = 0;
             currWeekDurationSum = 0;
@@ -256,7 +263,10 @@ export default function SchedulingModal({
             <p className='flex gap-1'>
               총 재생 시간 :
               <span className='text-sroom-brand'>
-                {getFormattedTime(convertSecondsToMinutes(duration as number), true)}
+                {getFormattedTime(
+                  convertSecondsToMinutes(duration as number),
+                  true
+                )}
               </span>
             </p>
             <Button

--- a/src/components/lectureEnrollment/SchedulingModal.tsx
+++ b/src/components/lectureEnrollment/SchedulingModal.tsx
@@ -66,7 +66,7 @@ export default function SchedulingModal({
         const navigateToCourseTaking = setTimeout(() => {
           router.push(`/course/${response.course_id}`);
         }, 5 * ONE_SECOND_IN_MS);
-        setLectureEnrollToast(() => {
+        setLectureEnrollToast(lecture_code, () => {
           clearTimeout(navigateToCourseTaking);
           toast.remove('lecture_enrollment');
         });

--- a/src/components/login/LoginButton.tsx
+++ b/src/components/login/LoginButton.tsx
@@ -4,6 +4,7 @@ import useAuth from '@/src/hooks/useAuth';
 import Script from 'next/script';
 import useWindowSize from '@/src/hooks/useWindowSize';
 import { BROWSER_MIN_WIDTH } from '@/src/constants/window/window';
+import LoadingSpinner from '../ui/LoadingSpinner';
 
 type Props = {
   className?: string;
@@ -12,7 +13,7 @@ type Props = {
 
 export default function LoginButton({ className, buttonWidth: width = 100 }: Props) {
   const loginButton = useRef<HTMLDivElement>(null);
-  const { login, status } = useAuth();
+  const { login, status, isLoading } = useAuth();
   const { width: windowWidth } = useWindowSize();
 
   const onload = async () => {
@@ -48,6 +49,11 @@ export default function LoginButton({ className, buttonWidth: width = 100 }: Pro
             id='google-login-button'
             ref={loginButton}
           />
+          {
+            isLoading && (
+             <LoadingSpinner className='absolute -translate-x-1/2 left-1/2 top-1/2 loading-lg text-sroom-brand'/>
+            )
+          }
         </>
       )}
     </>

--- a/src/components/tools/NaverAnalytics/NaverAnalytics.tsx
+++ b/src/components/tools/NaverAnalytics/NaverAnalytics.tsx
@@ -3,7 +3,7 @@ import Script from 'next/script';
 export default function NaverAnalytics({}) {
   return (
     <>
-      <Script type='text/javascript' src='//wcs.naver.net/wcslog.js'></Script>
+      <Script async type='text/javascript' src='//wcs.naver.net/wcslog.js'></Script>
       <Script
         id='naver-analytics-init'
         type='text/javascript'

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { AnimatePresence, motion } from 'framer-motion';
 import Button from './button/Button';
-import LectureSVG from '@/public/icon/Lecture';
 
 const Emoji: Emoji = {
   lecture_enrollment: '🤓',
@@ -56,11 +55,6 @@ export default function Toast({ toast }: { toast: CustomToast }) {
               onClick={buttonOnClick}
               className='flex items-center justify-center w-full h-full bg-sroom-brand'
             >
-              {type === 'lecture_enrollment' && (
-                <span className='w-3 mr-3 align-middle md:w-5 stroke-sroom-white fill-sroom-white'>
-                  <LectureSVG />
-                </span>
-              )}
               <span className='text-xs font-bold md:text-sm'>
                 {buttonLabel}
               </span>

--- a/src/components/ui/rating/StarRatingWithReviewCount.tsx
+++ b/src/components/ui/rating/StarRatingWithReviewCount.tsx
@@ -12,7 +12,7 @@ export default function StarRatingWithReviewCount({rating, review_count}: Props)
         <OneStar className='w-3 h-3' />
         <p className='text-xs font-medium text-sroom-brand'>{rating}</p>
       </div>
-      <p className='text-xs font-medium underline text-sroom-brand'>
+      <p className='text-xs font-medium text-sroom-brand'>
         후기 {review_count.toLocaleString()}개
       </p>
     </div>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,11 +2,12 @@ import { signIn, signOut, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { ErrorMessage } from '../api/ErrorMessage';
 import setErrorToast from '../util/toast/setErrorToast';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useAuth() {
   const router = useRouter();
   const { data: session, status } = useSession();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (session?.error === 'RefreshAccessTokenError') {
@@ -16,6 +17,7 @@ export default function useAuth() {
 
   const login = async (googleResponse: GoogleLoginCredential) => {
     if (!googleResponse) return;
+    setIsLoading(() => true);
 
     await signIn('credentials', {
       credential: googleResponse.credential,
@@ -30,6 +32,8 @@ export default function useAuth() {
         setErrorToast(err);
       });
 
+    setIsLoading(() => false);
+
     router.refresh();
   };
 
@@ -40,5 +44,5 @@ export default function useAuth() {
     });
   };
 
-  return { session, status, login, logout };
+  return { session, status, login, logout, isLoading };
 }

--- a/src/util/toast/setLectureEnrollToast.ts
+++ b/src/util/toast/setLectureEnrollToast.ts
@@ -7,7 +7,7 @@ export default function setLectureEnrollToast(buttonOnClick: () => void) {
     type: 'lecture_enrollment',
     title: '강의가 등록됐어요!',
     description: '5초 후에 수강 페이지로 이동해요!',
-    buttonLabel: '좀 더 둘러볼래요',
+    buttonLabel: '👀 좀 더 둘러볼래요',
     buttonOnClick
   };
   const param = {

--- a/src/util/toast/setLectureEnrollToast.ts
+++ b/src/util/toast/setLectureEnrollToast.ts
@@ -6,8 +6,8 @@ export default function setLectureEnrollToast(buttonOnClick: () => void) {
   const lectureEnrollToast: CustomToast = {
     type: 'lecture_enrollment',
     title: '강의가 등록됐어요!',
-    description: '지금 바로 수강을 시작해보세요',
-    buttonLabel: '수강하러 가기',
+    description: '5초 후에 수강 페이지로 이동해요!',
+    buttonLabel: '좀 더 둘러볼래요',
     buttonOnClick
   };
   const param = {

--- a/src/util/toast/setLectureEnrollToast.ts
+++ b/src/util/toast/setLectureEnrollToast.ts
@@ -2,12 +2,12 @@ import toast from 'react-hot-toast';
 import Toast from '../../components/ui/Toast';
 import { TOAST_TIMEOUT } from '.';
 
-export default function setLectureEnrollToast(buttonOnClick: () => void) {
+export default function setLectureEnrollToast(lectureCode: string, buttonOnClick: () => void) {
   const lectureEnrollToast: CustomToast = {
     type: 'lecture_enrollment',
     title: '강의가 등록됐어요!',
     description: '5초 후에 수강 페이지로 이동해요!',
-    buttonLabel: '👀 좀 더 둘러볼래요',
+    buttonLabel: '좀 더 둘러볼래요 👀',
     buttonOnClick
   };
   const param = {
@@ -15,7 +15,7 @@ export default function setLectureEnrollToast(buttonOnClick: () => void) {
   };
 
   toast.custom(() => Toast(param), {
-    id: 'lecture_enrollment',
+    id: `lecture_enrollment_${lectureCode}`,
     duration: TOAST_TIMEOUT,
     position: 'bottom-center',
     ariaProps: {

--- a/src/util/toast/setVideoCompleteToast.ts
+++ b/src/util/toast/setVideoCompleteToast.ts
@@ -2,7 +2,7 @@ import toast from 'react-hot-toast';
 import Toast from '../../components/ui/Toast';
 import { TOAST_TIMEOUT } from '.';
 
-export default function setVideoCompleteToast() {
+export default function setVideoCompleteToast(courseVideoId: number) {
   const videoCompleteToast: CustomToast = {
     type: 'video_complete',
     title: '수강이 완료됐어요!',
@@ -13,7 +13,7 @@ export default function setVideoCompleteToast() {
   };
 
   toast.custom(() => Toast(param), {
-    id: 'video_complete',
+    id: `video_complete_${courseVideoId}`,
     duration: TOAST_TIMEOUT,
     position: 'bottom-center',
     ariaProps: {


### PR DESCRIPTION
## Motivation 🤔
- 서비스 이용 플로우가 중간에 끊기는 느낌을 해소하기 위해

<br>

## Key changes ✅
### 강의 등록 시 수강 페이지로 이동
- 강의를 등록하면, 5초 후에 수강 페이지로 이동하도록 플로우 개선
- 하단 토스트의 `좀 더 둘러볼래요 👀` 버튼을 누르면 이동을 취소할 수 있음
![ezgif com-video-to-gif (32)](https://github.com/4m9d/sroom-fe/assets/63336701/1d16b1c2-59da-447b-a342-4b229254ec88)

### 수강 완료 시 후기 작성 모달 띄우기
- ~~수강이 완료 처리 되면 (코스의 경우, 마지막 영상이 시청 완료 처리 되면)~~ 후기 작성 모달을 자동으로 띄워주도록 개선
(코스의 progress가 100%가 됐을 때 띄우는 것으로 수정)
![ezgif com-video-to-gif (34)](https://github.com/4m9d/sroom-fe/assets/63336701/8fdf11dc-07fd-4898-b3c0-a98ae5fce53c)

### 수강 페이지의 `강의 자료 보기` 버튼에 pulse 애니메이션 추가
- 강의 자료 사이드 바가 접혀있을 때만 pulse 애니메이션으로 시선을 끌 수 있도록 개선
![ezgif com-video-to-gif (33)](https://github.com/4m9d/sroom-fe/assets/63336701/db7eebee-b823-433f-ab19-dfd9a27d9599)

### 퀴즈 복습 컴포넌트 색상 변경
- 문제와 답을 쉽게 구별할 수 있도록 배경 색상에 차이를 두어 개선
![ezgif com-video-to-gif (31)](https://github.com/4m9d/sroom-fe/assets/63336701/bc8f5cc9-a14b-44c1-a597-4b3084ba0271)

### 이외의 자잘한 수정사항
- 닉네임 수정 시, 바깥을 클릭하여 입력창이 닫히면 원래 닉네임 수정이 취소되도록 설정(원래 닉네임으로 복원)
- 로그인 화면에서 로딩 스피너 추가

<br>

## To reviewers 🙏
- 테섭에서 확인해주세용